### PR TITLE
Remove secret name from methods.

### DIFF
--- a/fs2/src/main/scala/uk/gov/nationalarchives/dp/client/fs2/Fs2Client.scala
+++ b/fs2/src/main/scala/uk/gov/nationalarchives/dp/client/fs2/Fs2Client.scala
@@ -1,6 +1,6 @@
 package uk.gov.nationalarchives.dp.client.fs2
 
-import cats.effect.IO
+import cats.effect._
 import sttp.capabilities.fs2.Fs2Streams
 import sttp.client3.httpclient.fs2.HttpClientFs2Backend
 import uk.gov.nationalarchives.dp.client.EntityClient._
@@ -16,28 +16,31 @@ object Fs2Client {
 
   def entityClient(
       url: String,
+      secretName: String,
       duration: FiniteDuration = 15.minutes,
       ssmEndpointUri: String = defaultSecretsManagerEndpoint
   ): IO[EntityClient[IO, Fs2Streams[IO]]] =
     HttpClientFs2Backend.resource[IO]().use { backend =>
-      cats.effect.IO(createEntityClient(ClientConfig(url, LoggingWrapper(backend), duration, ssmEndpointUri)))
+      IO(createEntityClient(ClientConfig(url, secretName, LoggingWrapper(backend), duration, ssmEndpointUri)))
     }
 
   def adminClient(
       url: String,
+      secretName: String,
       duration: FiniteDuration = 15.minutes,
       ssmEndpointUri: String = defaultSecretsManagerEndpoint
   ): IO[AdminClient[IO]] =
     HttpClientFs2Backend.resource[IO]().use { backend =>
-      cats.effect.IO(createAdminClient(ClientConfig(url, LoggingWrapper(backend), duration, ssmEndpointUri)))
+      IO(createAdminClient(ClientConfig(url, secretName, LoggingWrapper(backend), duration, ssmEndpointUri)))
     }
 
   def contentClient(
       url: String,
+      secretName: String,
       duration: FiniteDuration = 15.minutes,
       ssmEndpointUri: String = defaultSecretsManagerEndpoint
   ): IO[ContentClient[IO]] =
     HttpClientFs2Backend.resource[IO]().use { backend =>
-      cats.effect.IO(createContentClient(ClientConfig(url, LoggingWrapper(backend), duration, ssmEndpointUri)))
+      IO(createContentClient(ClientConfig(url, secretName, LoggingWrapper(backend), duration, ssmEndpointUri)))
     }
 }

--- a/fs2/src/test/scala/uk/gov/nationalarchives/dp/client/fs2/Fs2AdminClientTest.scala
+++ b/fs2/src/test/scala/uk/gov/nationalarchives/dp/client/fs2/Fs2AdminClientTest.scala
@@ -10,5 +10,5 @@ class Fs2AdminClientTest extends AdminClientTest[IO](9003, 9007) {
   override def valueFromF[T](value: IO[T]): T = value.unsafeRunSync()
 
   override def createClient(url: String): IO[AdminClient[IO]] =
-    adminClient(url, zeroSeconds, ssmEndpointUri = "http://localhost:9007")
+    adminClient(url, "secret", zeroSeconds, ssmEndpointUri = "http://localhost:9007")
 }

--- a/fs2/src/test/scala/uk/gov/nationalarchives/dp/client/fs2/Fs2ContentClientTest.scala
+++ b/fs2/src/test/scala/uk/gov/nationalarchives/dp/client/fs2/Fs2ContentClientTest.scala
@@ -10,5 +10,5 @@ class Fs2ContentClientTest extends ContentClientTest[IO](9006, 9008) {
   override def valueFromF[T](value: IO[T]): T = value.unsafeRunSync()
 
   override def createClient(url: String): IO[ContentClient[IO]] =
-    contentClient(url, zeroSeconds, ssmEndpointUri = "http://localhost:9008")
+    contentClient(url, "secret", zeroSeconds, ssmEndpointUri = "http://localhost:9008")
 }

--- a/fs2/src/test/scala/uk/gov/nationalarchives/dp/client/fs2/Fs2EntityClientTest.scala
+++ b/fs2/src/test/scala/uk/gov/nationalarchives/dp/client/fs2/Fs2EntityClientTest.scala
@@ -11,5 +11,5 @@ class Fs2EntityClientTest extends EntityClientTest[IO, Fs2Streams[IO]](9002, 900
   override def valueFromF[T](value: IO[T]): T = value.unsafeRunSync()
 
   override def createClient(url: String): IO[EntityClient[IO, Fs2Streams[IO]]] =
-    entityClient(url, zeroSeconds, ssmEndpointUri = "http://localhost:9009")
+    entityClient(url, "secret", zeroSeconds, ssmEndpointUri = "http://localhost:9009")
 }

--- a/src/main/scala/uk/gov/nationalarchives/dp/client/ContentClient.scala
+++ b/src/main/scala/uk/gov/nationalarchives/dp/client/ContentClient.scala
@@ -16,7 +16,7 @@ import java.time.format.DateTimeFormatter
 import java.util.UUID
 
 trait ContentClient[F[_]] {
-  def findExpiredClosedDocuments(secretName: String): F[List[Entity]]
+  def findExpiredClosedDocuments(): F[List[Entity]]
 }
 object ContentClient {
   case class SearchField(name: String, values: List[String])
@@ -26,7 +26,6 @@ object ContentClient {
       me: MonadError[F, Throwable],
       sync: Sync[F]
   ): ContentClient[F] = new ContentClient[F] {
-
     case class SearchResponseValue(objectIds: List[String], totalHits: Int)
 
     case class SearchResponse(success: Boolean, value: SearchResponseValue)
@@ -101,9 +100,9 @@ object ContentClient {
       uri"$apiBaseUrl/api/content/search?$queryParams"
     }
 
-    override def findExpiredClosedDocuments(secretName: String): F[List[Entity]] = {
+    override def findExpiredClosedDocuments(): F[List[Entity]] = {
       for {
-        token <- getAuthenticationToken(secretName)
+        token <- getAuthenticationToken
         indexNames <- getClosureResultIndexNames(token)
         res <- search(0, token, indexNames, Nil)
       } yield res

--- a/src/test/scala/uk/gov/nationalarchives/dp/client/AdminClientTest.scala
+++ b/src/test/scala/uk/gov/nationalarchives/dp/client/AdminClientTest.scala
@@ -73,7 +73,6 @@ abstract class AdminClientTest[F[_]](preservicaPort: Int, secretsManagerPort: In
   val metadataTemplateInfo: MetadataTemplateInfo =
     MetadataTemplateInfo("test-file-name", testXmlData.toString)
 
-  val secretName: String = "secretName"
   val tokenResponse: String = """{"token": "abcde"}"""
   val tokenUrl = "/api/accesstoken/login"
 
@@ -89,10 +88,10 @@ abstract class AdminClientTest[F[_]](preservicaPort: Int, secretsManagerPort: In
 
   forAll(t)((methodName, path, response, input) => {
     val result = input match {
-      case i: IndexDefinitionInfo   => client.addOrUpdateIndexDefinitions(i :: Nil, secretName)
-      case mt: MetadataTemplateInfo => client.addOrUpdateMetadataTemplates(mt :: Nil, secretName)
-      case s: SchemaFileInfo        => client.addOrUpdateSchemas(s :: Nil, secretName)
-      case t: TransformFileInfo     => client.addOrUpdateTransforms(t :: Nil, secretName)
+      case i: IndexDefinitionInfo   => client.addOrUpdateIndexDefinitions(i :: Nil)
+      case mt: MetadataTemplateInfo => client.addOrUpdateMetadataTemplates(mt :: Nil)
+      case s: SchemaFileInfo        => client.addOrUpdateSchemas(s :: Nil)
+      case t: TransformFileInfo     => client.addOrUpdateTransforms(t :: Nil)
     }
 
     val url = s"/api/admin/$path"

--- a/src/test/scala/uk/gov/nationalarchives/dp/client/ContentClientTest.scala
+++ b/src/test/scala/uk/gov/nationalarchives/dp/client/ContentClientTest.scala
@@ -74,7 +74,7 @@ abstract class ContentClientTest[F[_]](preservicaPort: Int, secretsManagerPort: 
       .willReturn(okJson(searchResponse))
     preservicaServer.stubFor(searchMapping)
 
-    valueFromF(client.findExpiredClosedDocuments("secretName"))
+    valueFromF(client.findExpiredClosedDocuments())
 
     val events =
       preservicaServer.getServeEvents(ServeEventQuery.forStubMapping(searchMapping.build())).getServeEvents.asScala
@@ -100,7 +100,7 @@ abstract class ContentClientTest[F[_]](preservicaPort: Int, secretsManagerPort: 
     preservicaServer.stubFor(get(urlPathMatching("/api/admin/documents")).willReturn(okXml(documentResponse.toString)))
 
     val error = intercept[PreservicaClientException] {
-      valueFromF(client.findExpiredClosedDocuments("secretName"))
+      valueFromF(client.findExpiredClosedDocuments())
     }
     error.getMessage should equal("Cannot find index definition closure-result-index-definition")
   }
@@ -126,7 +126,7 @@ abstract class ContentClientTest[F[_]](preservicaPort: Int, secretsManagerPort: 
         .willReturn(okXml(documentContentResponse.toString))
     )
     val error = intercept[PreservicaClientException] {
-      valueFromF(client.findExpiredClosedDocuments("secretName"))
+      valueFromF(client.findExpiredClosedDocuments())
     }
     error.getMessage should equal("No review date index found for closure result")
   }
@@ -167,7 +167,7 @@ abstract class ContentClientTest[F[_]](preservicaPort: Int, secretsManagerPort: 
     preservicaServer.stubFor(firstSearchMapping)
     preservicaServer.stubFor(secondSearchMapping)
 
-    valueFromF(client.findExpiredClosedDocuments("secretName"))
+    valueFromF(client.findExpiredClosedDocuments())
 
     val firstEvents =
       preservicaServer.getServeEvents(ServeEventQuery.forStubMapping(firstSearchMapping.build())).getServeEvents.asScala

--- a/src/test/scala/uk/gov/nationalarchives/dp/client/EntityClientTest.scala
+++ b/src/test/scala/uk/gov/nationalarchives/dp/client/EntityClientTest.scala
@@ -63,7 +63,6 @@ abstract class EntityClientTest[F[_], S](preservicaPort: Int, secretsManagerPort
   def checkServerCall(url: String): Assertion =
     preservicaServer.getAllServeEvents.asScala.count(_.getRequest.getUrl == url) should equal(1)
 
-  val secretName: String = "secretName"
   val tokenResponse: String = """{"token": "abcde"}"""
   val tokenUrl = "/api/accesstoken/login"
 
@@ -113,7 +112,7 @@ abstract class EntityClientTest[F[_], S](preservicaPort: Int, secretsManagerPort
       )
 
       val client = testClient(s"http://localhost:$preservicaPort")
-      val addEntityResponse: F[UUID] = client.addEntity(addEntityRequest, secretName)
+      val addEntityResponse: F[UUID] = client.addEntity(addEntityRequest)
 
       val _ = valueFromF(addEntityResponse)
 
@@ -164,7 +163,7 @@ abstract class EntityClientTest[F[_], S](preservicaPort: Int, secretsManagerPort
     )
 
     val client = testClient(s"http://localhost:$preservicaPort")
-    val addEntityResponse: F[UUID] = client.addEntity(addEntityRequest, secretName)
+    val addEntityResponse: F[UUID] = client.addEntity(addEntityRequest)
 
     val _ = valueFromF(addEntityResponse)
 
@@ -195,7 +194,7 @@ abstract class EntityClientTest[F[_], S](preservicaPort: Int, secretsManagerPort
     )
 
     val client = testClient(s"http://localhost:$preservicaPort")
-    val addEntityResponse: F[UUID] = client.addEntity(addEntityRequest, secretName)
+    val addEntityResponse: F[UUID] = client.addEntity(addEntityRequest)
 
     val error = intercept[PreservicaClientException] {
       valueFromF(addEntityResponse)
@@ -215,7 +214,7 @@ abstract class EntityClientTest[F[_], S](preservicaPort: Int, secretsManagerPort
       None
     )
 
-    val addEntityResponse: F[UUID] = client.addEntity(addEntityRequest, secretName)
+    val addEntityResponse: F[UUID] = client.addEntity(addEntityRequest)
 
     val error = intercept[PreservicaClientException] {
       valueFromF(addEntityResponse)
@@ -257,7 +256,7 @@ abstract class EntityClientTest[F[_], S](preservicaPort: Int, secretsManagerPort
     )
 
     val client = testClient(s"http://localhost:$preservicaPort")
-    val addEntityResponse: F[UUID] = client.addEntity(addEntityRequest, secretName)
+    val addEntityResponse: F[UUID] = client.addEntity(addEntityRequest)
 
     val response = valueFromF(addEntityResponse)
 
@@ -280,7 +279,7 @@ abstract class EntityClientTest[F[_], S](preservicaPort: Int, secretsManagerPort
     val client = testClient(s"http://localhost:$preservicaPort")
 
     val error = intercept[PreservicaClientException] {
-      valueFromF(client.addEntity(updateEntityRequest, secretName))
+      valueFromF(client.addEntity(updateEntityRequest))
     }
 
     error.getMessage should equal(
@@ -324,7 +323,7 @@ abstract class EntityClientTest[F[_], S](preservicaPort: Int, secretsManagerPort
         )
 
         val client = testClient(s"http://localhost:$preservicaPort")
-        val updateEntityResponse: F[String] = client.updateEntity(updateEntityRequest, secretName)
+        val updateEntityResponse: F[String] = client.updateEntity(updateEntityRequest)
 
         val _ = valueFromF(updateEntityResponse)
 
@@ -357,7 +356,7 @@ abstract class EntityClientTest[F[_], S](preservicaPort: Int, secretsManagerPort
       None
     )
 
-    val updateEntityResponse: F[String] = client.updateEntity(updateEntityRequest, secretName)
+    val updateEntityResponse: F[String] = client.updateEntity(updateEntityRequest)
 
     val error = intercept[PreservicaClientException] {
       valueFromF(updateEntityResponse)
@@ -399,7 +398,7 @@ abstract class EntityClientTest[F[_], S](preservicaPort: Int, secretsManagerPort
     )
 
     val client = testClient(s"http://localhost:$preservicaPort")
-    val updateEntityResponse: F[String] = client.updateEntity(updateEntityRequest, secretName)
+    val updateEntityResponse: F[String] = client.updateEntity(updateEntityRequest)
 
     val response = valueFromF(updateEntityResponse)
 
@@ -424,7 +423,7 @@ abstract class EntityClientTest[F[_], S](preservicaPort: Int, secretsManagerPort
     val client = testClient(s"http://localhost:$preservicaPort")
 
     val error = intercept[PreservicaClientException] {
-      valueFromF(client.updateEntity(updateEntityRequest, secretName))
+      valueFromF(client.updateEntity(updateEntityRequest))
     }
 
     error.getMessage should equal(
@@ -458,7 +457,7 @@ abstract class EntityClientTest[F[_], S](preservicaPort: Int, secretsManagerPort
 
     val client = testClient(s"http://localhost:$preservicaPort")
     val response: F[Map[String, String]] =
-      client.nodesFromEntity(ref, ContentObject, List("parent", "description"), secretName)
+      client.nodesFromEntity(ref, ContentObject, List("parent", "description"))
 
     val nodeAndValue = valueFromF(response)
     nodeAndValue.size should equal(2)
@@ -494,7 +493,7 @@ abstract class EntityClientTest[F[_], S](preservicaPort: Int, secretsManagerPort
     preservicaServer.stubFor(get(urlEqualTo(entityUrl)).willReturn(ok(entityResponse)))
 
     val client = testClient(s"http://localhost:$preservicaPort")
-    val response: F[Map[String, String]] = client.nodesFromEntity(ref, ContentObject, Nil, secretName)
+    val response: F[Map[String, String]] = client.nodesFromEntity(ref, ContentObject, Nil)
 
     val nodeAndValue = valueFromF(response)
     nodeAndValue.size should equal(0)
@@ -543,7 +542,7 @@ abstract class EntityClientTest[F[_], S](preservicaPort: Int, secretsManagerPort
     preservicaServer.stubFor(get(urlEqualTo(bitstreamUrl)).willReturn(ok(bitstreamResponse)))
 
     val client = testClient(s"http://localhost:$preservicaPort")
-    val response: F[Seq[BitStreamInfo]] = client.getBitstreamInfo(ref, secretName)
+    val response: F[Seq[BitStreamInfo]] = client.getBitstreamInfo(ref)
 
     val bitStreamInfo = valueFromF(response).head
     bitStreamInfo.url should equal(s"http://test")
@@ -621,7 +620,7 @@ abstract class EntityClientTest[F[_], S](preservicaPort: Int, secretsManagerPort
     preservicaServer.stubFor(get(urlEqualTo(bitstreamTwoUrl)).willReturn(ok(bitstreamTwoResponse)))
 
     val client = testClient(s"http://localhost:$preservicaPort")
-    val response: F[Seq[BitStreamInfo]] = client.getBitstreamInfo(ref, secretName)
+    val response: F[Seq[BitStreamInfo]] = client.getBitstreamInfo(ref)
 
     val bitStreamInfo = valueFromF(response)
     bitStreamInfo.size should equal(2)
@@ -648,7 +647,7 @@ abstract class EntityClientTest[F[_], S](preservicaPort: Int, secretsManagerPort
     preservicaServer.stubFor(get(urlEqualTo(entityUrl)).willReturn(ok(entityResponse)))
 
     val client = testClient(s"http://localhost:$preservicaPort")
-    val response: F[Seq[BitStreamInfo]] = client.getBitstreamInfo(ref, secretName)
+    val response: F[Seq[BitStreamInfo]] = client.getBitstreamInfo(ref)
 
     val expectedError = valueFromF(cme.attempt(response))
 
@@ -663,7 +662,7 @@ abstract class EntityClientTest[F[_], S](preservicaPort: Int, secretsManagerPort
     preservicaServer.stubFor(post(urlEqualTo(tokenUrl)).willReturn(serverError()))
 
     val client = testClient(s"http://localhost:$preservicaPort")
-    val response = client.getBitstreamInfo(UUID.randomUUID(), secretName)
+    val response = client.getBitstreamInfo(UUID.randomUUID())
 
     val expectedError = valueFromF(cme.attempt(response))
 
@@ -683,7 +682,6 @@ abstract class EntityClientTest[F[_], S](preservicaPort: Int, secretsManagerPort
 
     val response = client.streamBitstreamContent[String](stream)(
       s"$url/bitstream/1",
-      secretName,
       _ => cme.pure(s"Test return value")
     )
     val responseValue = valueFromF(response)
@@ -697,7 +695,7 @@ abstract class EntityClientTest[F[_], S](preservicaPort: Int, secretsManagerPort
 
     val client = testClient(s"http://localhost:$preservicaPort")
     val response =
-      client.streamBitstreamContent[Unit](stream)(s"$url/bitstream/1", secretName, _ => cme.unit)
+      client.streamBitstreamContent[Unit](stream)(s"$url/bitstream/1", _ => cme.unit)
 
     val expectedError = valueFromF(cme.attempt(response))
 
@@ -744,7 +742,7 @@ abstract class EntityClientTest[F[_], S](preservicaPort: Int, secretsManagerPort
 
     val client = testClient(url)
 
-    val res = client.metadataForEntity(entity, secretName)
+    val res = client.metadataForEntity(entity)
     val metadata = valueFromF(res)
 
     metadata.size should equal(1)
@@ -806,7 +804,7 @@ abstract class EntityClientTest[F[_], S](preservicaPort: Int, secretsManagerPort
 
     val client = testClient(url)
 
-    val res = client.metadataForEntity(entity, secretName)
+    val res = client.metadataForEntity(entity)
     val metadata = valueFromF(res)
 
     metadata.size should equal(2)
@@ -836,7 +834,7 @@ abstract class EntityClientTest[F[_], S](preservicaPort: Int, secretsManagerPort
 
     val client = testClient(url)
 
-    val res = client.metadataForEntity(entity, secretName)
+    val res = client.metadataForEntity(entity)
     val error = intercept[PreservicaClientException] {
       valueFromF(res)
     }
@@ -850,7 +848,7 @@ abstract class EntityClientTest[F[_], S](preservicaPort: Int, secretsManagerPort
     preservicaServer.stubFor(post(urlEqualTo(tokenUrl)).willReturn(serverError()))
     val entity = valueFromF(fromType("IO", UUID.randomUUID(), Option("title"), Option("description"), deleted = false))
     val client = testClient(s"http://localhost:$preservicaPort")
-    val response = client.metadataForEntity(entity, secretName)
+    val response = client.metadataForEntity(entity)
 
     val expectedError = valueFromF(cme.attempt(response))
 
@@ -868,7 +866,7 @@ abstract class EntityClientTest[F[_], S](preservicaPort: Int, secretsManagerPort
     preservicaServer.stubFor(post(urlEqualTo(tokenUrl)).willReturn(ok(tokenResponse)))
     val client = testClient(s"http://localhost:$preservicaPort")
     val ex = intercept[PreservicaClientException] {
-      valueFromF(client.metadataForEntity(entity, secretName))
+      valueFromF(client.metadataForEntity(entity))
     }
     ex.getMessage should equal(s"No path found for entity id $id. Could this entity have been deleted?")
   }
@@ -904,7 +902,7 @@ abstract class EntityClientTest[F[_], S](preservicaPort: Int, secretsManagerPort
     )
 
     val client = testClient(s"http://localhost:$preservicaPort")
-    val response = valueFromF(client.entitiesUpdatedSince(date, secretName, 0))
+    val response = valueFromF(client.entitiesUpdatedSince(date, 0))
 
     val expectedEntity = response.head
 
@@ -934,7 +932,7 @@ abstract class EntityClientTest[F[_], S](preservicaPort: Int, secretsManagerPort
     )
 
     val client = testClient(s"http://localhost:$preservicaPort")
-    val response = valueFromF(client.entitiesUpdatedSince(date, secretName, 0))
+    val response = valueFromF(client.entitiesUpdatedSince(date, 0))
 
     response.size should equal(0)
   }
@@ -956,7 +954,7 @@ abstract class EntityClientTest[F[_], S](preservicaPort: Int, secretsManagerPort
     )
 
     val client = testClient(s"http://localhost:$preservicaPort")
-    val response = valueFromF(cme.attempt(client.entitiesUpdatedSince(date, secretName, 0)))
+    val response = valueFromF(cme.attempt(client.entitiesUpdatedSince(date, 0)))
 
     response.left.map(err => {
       err.getClass.getSimpleName should equal("PreservicaClientException")
@@ -1030,8 +1028,7 @@ abstract class EntityClientTest[F[_], S](preservicaPort: Int, secretsManagerPort
           None,
           deleted = false,
           ContentObject.entityPath.some
-        ),
-        secretName
+        )
       )
     )
 
@@ -1071,8 +1068,7 @@ abstract class EntityClientTest[F[_], S](preservicaPort: Int, secretsManagerPort
             None,
             deleted = false,
             ContentObject.entityPath.some
-          ),
-          secretName
+          )
         )
       )
     )
@@ -1095,8 +1091,7 @@ abstract class EntityClientTest[F[_], S](preservicaPort: Int, secretsManagerPort
             None,
             deleted = true,
             None
-          ),
-          secretName
+          )
         )
       )
     }
@@ -1130,7 +1125,7 @@ abstract class EntityClientTest[F[_], S](preservicaPort: Int, secretsManagerPort
 
     val client = testClient(s"http://localhost:$preservicaPort")
     val response = valueFromF(
-      client.entitiesByIdentifier(Identifier("testIdentifier", "testValue"), secretName)
+      client.entitiesByIdentifier(Identifier("testIdentifier", "testValue"))
     )
 
     val expectedEntity = response.head
@@ -1160,7 +1155,7 @@ abstract class EntityClientTest[F[_], S](preservicaPort: Int, secretsManagerPort
 
     val client = testClient(s"http://localhost:$preservicaPort")
     val response = valueFromF(
-      client.entitiesByIdentifier(Identifier("testIdentifier", "testValueDoesNotExist"), secretName)
+      client.entitiesByIdentifier(Identifier("testIdentifier", "testValueDoesNotExist"))
     )
 
     response.size should equal(0)
@@ -1182,7 +1177,7 @@ abstract class EntityClientTest[F[_], S](preservicaPort: Int, secretsManagerPort
     val client = testClient(s"http://localhost:$preservicaPort")
     val response = valueFromF(
       cme.attempt(
-        client.entitiesByIdentifier(Identifier("testIdentifier", "testValue"), secretName)
+        client.entitiesByIdentifier(Identifier("testIdentifier", "testValue"))
       )
     )
 
@@ -1217,7 +1212,7 @@ abstract class EntityClientTest[F[_], S](preservicaPort: Int, secretsManagerPort
 
     val client = testClient(s"http://localhost:$preservicaPort")
     val addIdentifierForEntityResponse: F[String] =
-      client.addIdentifierForEntity(ref, StructuralObject, identifier, secretName)
+      client.addIdentifierForEntity(ref, StructuralObject, identifier)
 
     val _ = valueFromF(addIdentifierForEntityResponse)
 
@@ -1242,7 +1237,7 @@ abstract class EntityClientTest[F[_], S](preservicaPort: Int, secretsManagerPort
 
     val client = testClient(s"http://localhost:$preservicaPort")
     val addIdentifierForEntityResponse: F[String] =
-      client.addIdentifierForEntity(ref, StructuralObject, identifier, secretName)
+      client.addIdentifierForEntity(ref, StructuralObject, identifier)
 
     val error = intercept[PreservicaClientException] {
       valueFromF(addIdentifierForEntityResponse)
@@ -1281,7 +1276,7 @@ abstract class EntityClientTest[F[_], S](preservicaPort: Int, secretsManagerPort
 
     val client = testClient(s"http://localhost:$preservicaPort")
     val addIdentifierForEntityResponse: F[String] =
-      client.addIdentifierForEntity(ref, StructuralObject, identifier, secretName)
+      client.addIdentifierForEntity(ref, StructuralObject, identifier)
 
     val response = valueFromF(addIdentifierForEntityResponse)
 

--- a/zio/src/main/scala/uk/gov/nationalarchives/dp/client/zio/ZioClient.scala
+++ b/zio/src/main/scala/uk/gov/nationalarchives/dp/client/zio/ZioClient.scala
@@ -17,28 +17,33 @@ object ZioClient {
 
   def entityClient(
       url: String,
+      secretName: String,
       duration: FiniteDuration = 15.minutes,
       ssmEndpointUri: String = defaultSecretsManagerEndpoint
   ): Task[EntityClient[Task, ZioStreams]] =
     HttpClientZioBackend().map { backend =>
-      createEntityClient[Task, ZioStreams](ClientConfig(url, LoggingWrapper(backend), duration, ssmEndpointUri))
+      createEntityClient[Task, ZioStreams](
+        ClientConfig(url, secretName, LoggingWrapper(backend), duration, ssmEndpointUri)
+      )
     }
 
   def adminClient(
       url: String,
+      secretName: String,
       duration: FiniteDuration = 15.minutes,
       ssmEndpointUri: String = defaultSecretsManagerEndpoint
   ): Task[AdminClient[Task]] =
     HttpClientZioBackend().map { backend =>
-      createAdminClient[Task, ZioStreams](ClientConfig(url, backend, duration, ssmEndpointUri))
+      createAdminClient[Task, ZioStreams](ClientConfig(url, secretName, backend, duration, ssmEndpointUri))
     }
 
   def contentClient(
       url: String,
+      secretName: String,
       duration: FiniteDuration = 15.minutes,
       ssmEndpointUri: String = defaultSecretsManagerEndpoint
   ): Task[ContentClient[Task]] =
     HttpClientZioBackend().map { backend =>
-      createContentClient[Task, ZioStreams](ClientConfig(url, backend, duration, ssmEndpointUri))
+      createContentClient[Task, ZioStreams](ClientConfig(url, secretName, backend, duration, ssmEndpointUri))
     }
 }

--- a/zio/src/test/scala/uk/gov/nationalarchives/dp/client/zio/ZioAdminClientTest.scala
+++ b/zio/src/test/scala/uk/gov/nationalarchives/dp/client/zio/ZioAdminClientTest.scala
@@ -12,5 +12,5 @@ class ZioAdminClientTest extends AdminClientTest[Task](9004, 9010) {
   }
 
   override def createClient(url: String): Task[AdminClient[Task]] =
-    adminClient(url, zeroSeconds, ssmEndpointUri = "http://localhost:9010")
+    adminClient(url, "secret", zeroSeconds, ssmEndpointUri = "http://localhost:9010")
 }

--- a/zio/src/test/scala/uk/gov/nationalarchives/dp/client/zio/ZioContentClientTest.scala
+++ b/zio/src/test/scala/uk/gov/nationalarchives/dp/client/zio/ZioContentClientTest.scala
@@ -11,5 +11,5 @@ class ZioContentClientTest extends ContentClientTest[Task](9001, 9011) {
   }
 
   override def createClient(url: String): Task[ContentClient[Task]] =
-    contentClient(url, zeroSeconds, ssmEndpointUri = "http://localhost:9011")
+    contentClient(url, "secret", zeroSeconds, ssmEndpointUri = "http://localhost:9011")
 }

--- a/zio/src/test/scala/uk/gov/nationalarchives/dp/client/zio/ZioEntityClientTest.scala
+++ b/zio/src/test/scala/uk/gov/nationalarchives/dp/client/zio/ZioEntityClientTest.scala
@@ -12,5 +12,5 @@ class ZioEntityClientTest extends EntityClientTest[Task, ZioStreams](9013, 9012,
   }
 
   override def createClient(url: String): Task[EntityClient[Task, ZioStreams]] =
-    entityClient(url, zeroSeconds, ssmEndpointUri = "http://localhost:9012")
+    entityClient(url, "secret", zeroSeconds, ssmEndpointUri = "http://localhost:9012")
 }


### PR DESCRIPTION
Each method takes a secret name but it is always the same within a
lambda. I've moved the secret name to the client config and removed it
from the individual methods.
