### PR TITLE
DR2-1289 Use the Identifier case class from DynamoFormatters

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -50,6 +50,7 @@ lazy val commonSettings = Seq(
   libraryDependencies ++= Seq(
     awsSecretsManager,
     catsCore,
+    dynamoFormatters,
     scalaCacheCore,
     log4Cats,
     scalaXml,

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -7,6 +7,7 @@ object Dependencies {
   lazy val scalaTest = "org.scalatest" %% "scalatest" % "3.2.17"
   lazy val scalaCacheCore = "com.github.cb372" %% "scalacache-core" % scalaCacheVersion
   lazy val scalaXml = "org.scala-lang.modules" %% "scala-xml" % "2.2.0"
+  lazy val dynamoFormatters = "uk.gov.nationalarchives" %% "dynamo-formatters" % "0.0.1"
   lazy val sttpCore = "com.softwaremill.sttp.client3" %% "core" % sttpVersion
   lazy val sttpFs2 = "com.softwaremill.sttp.client3" %% "fs2" % sttpVersion
   lazy val log4Cats = "org.typelevel" %% "log4cats-slf4j" % "2.6.0"

--- a/src/main/scala/uk/gov/nationalarchives/dp/client/Entities.scala
+++ b/src/main/scala/uk/gov/nationalarchives/dp/client/Entities.scala
@@ -39,6 +39,5 @@ object Entities {
     }
   }
 
-  case class Identifier(identifierName: String, value: String)
   case class IdentifierResponse(id: String, identifierName: String, value: String)
 }

--- a/src/main/scala/uk/gov/nationalarchives/dp/client/EntityClient.scala
+++ b/src/main/scala/uk/gov/nationalarchives/dp/client/EntityClient.scala
@@ -8,7 +8,8 @@ import sttp.client3._
 import sttp.model.Method
 import uk.gov.nationalarchives.dp.client.Client._
 import uk.gov.nationalarchives.dp.client.DataProcessor.EventAction
-import uk.gov.nationalarchives.dp.client.Entities.{Entity, Identifier, IdentifierResponse}
+import uk.gov.nationalarchives.dp.client.Entities.{Entity, IdentifierResponse}
+import uk.gov.nationalarchives.DynamoFormatters.Identifier
 import uk.gov.nationalarchives.dp.client.EntityClient.{AddEntityRequest, EntityType, UpdateEntityRequest}
 
 import java.time.ZonedDateTime

--- a/src/test/scala/uk/gov/nationalarchives/dp/client/EntityClientTest.scala
+++ b/src/test/scala/uk/gov/nationalarchives/dp/client/EntityClientTest.scala
@@ -13,7 +13,8 @@ import org.scalatest.prop.TableFor2
 import org.scalatest.prop.Tables.Table
 import org.scalatest.{Assertion, BeforeAndAfterEach}
 import sttp.capabilities.Streams
-import uk.gov.nationalarchives.dp.client.Entities.{Entity, Identifier, IdentifierResponse, fromType}
+import uk.gov.nationalarchives.dp.client.Entities.{Entity, IdentifierResponse, fromType}
+import uk.gov.nationalarchives.DynamoFormatters.Identifier
 import uk.gov.nationalarchives.dp.client.Client._
 import uk.gov.nationalarchives.dp.client.EntityClient.{
   AddEntityRequest,


### PR DESCRIPTION
This case class will be shared among the libraries so it makes sense to
have it here otherwise we'll have two case classes called Identifier.
