### PR TITLE
Add the CO title to the BitStreamInfo

### DIFF
--- a/src/main/scala/uk/gov/nationalarchives/dp/client/Client.scala
+++ b/src/main/scala/uk/gov/nationalarchives/dp/client/Client.scala
@@ -141,7 +141,7 @@ object Client {
     * @param url
     *   The url to download the bitstream
     */
-  case class BitStreamInfo(name: String, fileSize: Long, url: String, fixity: Fixity)
+  case class BitStreamInfo(name: String, fileSize: Long, url: String, fixity: Fixity, potentialCoTitle: Option[String])
 
   /** Configuration for the clients
     * @param apiBaseUrl

--- a/src/main/scala/uk/gov/nationalarchives/dp/client/DataProcessor.scala
+++ b/src/main/scala/uk/gov/nationalarchives/dp/client/DataProcessor.scala
@@ -152,7 +152,7 @@ class DataProcessor[F[_]]()(implicit me: MonadError[F, Throwable]) {
     * @return
     *   A `Seq` of `BitStreamInfo` objects parsed from the XML
     */
-  def allBitstreamInfo(entity: Seq[Elem]): F[Seq[BitStreamInfo]] = {
+  def allBitstreamInfo(entity: Seq[Elem], potentialCoTitle: Option[String] = None): F[Seq[BitStreamInfo]] = {
     me.pure {
       entity.map(e => {
         val filename = (e \\ "Bitstream" \\ "Filename").text
@@ -160,7 +160,7 @@ class DataProcessor[F[_]]()(implicit me: MonadError[F, Throwable]) {
         val url = (e \\ "AdditionalInformation" \\ "Content").text
         val fixityAlgorithm = (e \\ "Bitstream" \\ "Fixities" \\ "Fixity" \\ "FixityAlgorithmRef").text
         val fixityValue = (e \\ "Bitstream" \\ "Fixities" \\ "Fixity" \\ "FixityValue").text
-        BitStreamInfo(filename, fileSize, url, Fixity(fixityAlgorithm, fixityValue))
+        BitStreamInfo(filename, fileSize, url, Fixity(fixityAlgorithm, fixityValue), potentialCoTitle)
       })
     }
   }

--- a/src/main/scala/uk/gov/nationalarchives/dp/client/EntityClient.scala
+++ b/src/main/scala/uk/gov/nationalarchives/dp/client/EntityClient.scala
@@ -452,7 +452,8 @@ object EntityClient {
           .sequence
         allUrls <- dataProcessor.allBitstreamUrls(allGenerationElements)
         bitstreamXmls <- allUrls.map(url => sendXMLApiRequest(url, token, Method.GET)).sequence
-        allBitstreamInfo <- dataProcessor.allBitstreamInfo(bitstreamXmls)
+        contentObjectTitle <- dataProcessor.getEntity(contentRef, contentEntity, ContentObject)
+        allBitstreamInfo <- dataProcessor.allBitstreamInfo(bitstreamXmls, contentObjectTitle.title)
       } yield allBitstreamInfo
 
     override def metadataForEntity(entity: Entity): F[Seq[Elem]] =

--- a/src/test/scala/uk/gov/nationalarchives/dp/client/DataProcessorTest.scala
+++ b/src/test/scala/uk/gov/nationalarchives/dp/client/DataProcessorTest.scala
@@ -240,7 +240,7 @@ abstract class DataProcessorTest[F[_]](implicit cme: MonadError[F, Throwable]) e
       </BitstreamResponse>
     )
 
-    val generationsF = new DataProcessor[F]().allBitstreamInfo(input)
+    val generationsF = new DataProcessor[F]().allBitstreamInfo(input, Some("testCoTitle"))
     val response = valueFromF(generationsF)
 
     response.size should equal(1)
@@ -249,6 +249,7 @@ abstract class DataProcessorTest[F[_]](implicit cme: MonadError[F, Throwable]) e
     response.head.url should equal("http://test")
     response.head.fixity.algorithm should equal("SHA1")
     response.head.fixity.value should equal("0c16735b03fe46b931060858e8cd5ca9c5101565")
+    response.head.potentialCoTitle should equal(Some("testCoTitle"))
   }
 
   "getNextPage" should "return the next page" in {

--- a/src/test/scala/uk/gov/nationalarchives/dp/client/EntityClientTest.scala
+++ b/src/test/scala/uk/gov/nationalarchives/dp/client/EntityClientTest.scala
@@ -436,6 +436,13 @@ abstract class EntityClientTest[F[_], S](preservicaPort: Int, secretsManagerPort
 
     val entityResponse =
       <EntityResponse xmlns="http://preservica.com/EntityAPI/v6.5" xmlns:xip="http://preservica.com/XIP/v6.5">
+        <xip:ContentObject>
+          <xip:Ref>b2f07829-e167-499a-9f3e-727cf3f64468</xip:Ref>
+          <xip:Title>page1File.txt</xip:Title>
+          <xip:Description>A description</xip:Description>
+          <xip:SecurityTag>open</xip:SecurityTag>
+          <xip:Parent>a6771bd9-a4df-47fb-bcc1-982f0b42f7cb</xip:Parent>
+        </xip:ContentObject>
       <AdditionalInformation>
         <Generations>http://localhost:{preservicaPort}{generationsUrl}</Generations>
       </AdditionalInformation>
@@ -483,6 +490,7 @@ abstract class EntityClientTest[F[_], S](preservicaPort: Int, secretsManagerPort
     bitStreamInfo.fileSize should equal(1234)
     bitStreamInfo.fixity.algorithm should equal("SHA1")
     bitStreamInfo.fixity.value should equal("0c16735b03fe46b931060858e8cd5ca9c5101565")
+    bitStreamInfo.potentialCoTitle should equal(Some("page1File.txt"))
 
     checkServerCall(entityUrl)
     checkServerCall(generationsUrl)
@@ -498,10 +506,17 @@ abstract class EntityClientTest[F[_], S](preservicaPort: Int, secretsManagerPort
 
     val entityResponse =
       <EntityResponse xmlns="http://preservica.com/EntityAPI/v6.5" xmlns:xip="http://preservica.com/XIP/v6.5">
-      <AdditionalInformation>
-        <Generations>http://localhost:{preservicaPort}{generationsUrl}</Generations>
-      </AdditionalInformation>
-    </EntityResponse>.toString()
+        <xip:ContentObject>
+          <xip:Ref>b2f07829-e167-499a-9f3e-727cf3f64468</xip:Ref>
+          <xip:Title>page1File.txt</xip:Title>
+          <xip:Description>A description</xip:Description>
+          <xip:SecurityTag>open</xip:SecurityTag>
+          <xip:Parent>a6771bd9-a4df-47fb-bcc1-982f0b42f7cb</xip:Parent>
+        </xip:ContentObject>
+        <AdditionalInformation>
+          <Generations>http://localhost:{preservicaPort}{generationsUrl}</Generations>
+        </AdditionalInformation>
+      </EntityResponse>.toString()
     val generationsResponse =
       <GenerationsResponse xmlns="http://preservica.com/EntityAPI/v6.5" xmlns:xip="http://preservica.com/XIP/v6.5">
       <Generations>
@@ -577,12 +592,14 @@ abstract class EntityClientTest[F[_], S](preservicaPort: Int, secretsManagerPort
     bitStreamInfo.head.fileSize should equal(1234)
     bitStreamInfo.head.fixity.algorithm should equal("SHA1")
     bitStreamInfo.head.fixity.value should equal("0c16735b03fe46b931060858e8cd5ca9c5101565")
+    bitStreamInfo.head.potentialCoTitle should equal(Some("page1File.txt"))
 
     bitStreamInfo.last.url should equal(s"http://test")
     bitStreamInfo.last.name should equal("test2.txt")
     bitStreamInfo.last.fileSize should equal(1234)
     bitStreamInfo.last.fixity.algorithm should equal("SHA1")
     bitStreamInfo.last.fixity.value should equal("5e0a0af2f597bf6b06c5295fea11be74cf89e1c1")
+    bitStreamInfo.head.potentialCoTitle should equal(Some("page1File.txt"))
 
     checkServerCall(entityUrl)
     checkServerCall(generationsUrl)


### PR DESCRIPTION
A bitstream's name is a UUID + file extension, which might not be that useful; this commit adds the title of the CO (the bitstream belongs to) to the BitStreamInfo case class