### PR TITLE
Add parentRef to BitstreamInfo

### DIFF
--- a/src/main/scala/uk/gov/nationalarchives/dp/client/Client.scala
+++ b/src/main/scala/uk/gov/nationalarchives/dp/client/Client.scala
@@ -17,6 +17,7 @@ import uk.gov.nationalarchives.dp.client.EntityClient.GenerationType
 import upickle.default._
 
 import java.net.URI
+import java.util.UUID
 import scala.concurrent.duration._
 import scala.xml.{Elem, XML}
 
@@ -147,6 +148,8 @@ object Client {
     *   The url to download the bitstream
     * @param potentialCoTitle
     *   The url to download the bitstream
+    * @param parentRef
+    *   The parent ref of the CO
     */
   case class BitStreamInfo(
       name: String,
@@ -155,7 +158,8 @@ object Client {
       fixity: Fixity,
       generationVersion: Int,
       generationType: GenerationType,
-      potentialCoTitle: Option[String]
+      potentialCoTitle: Option[String],
+      parentRef: Option[UUID]
   )
 
   /** Configuration for the clients

--- a/src/main/scala/uk/gov/nationalarchives/dp/client/DataProcessor.scala
+++ b/src/main/scala/uk/gov/nationalarchives/dp/client/DataProcessor.scala
@@ -5,7 +5,7 @@ import cats.implicits._
 import uk.gov.nationalarchives.dp.client.Client._
 import uk.gov.nationalarchives.dp.client.DataProcessor.EventAction
 import uk.gov.nationalarchives.dp.client.Entities._
-import uk.gov.nationalarchives.dp.client.EntityClient._
+import uk.gov.nationalarchives.dp.client.EntityClient.{ContentObject, _}
 
 import java.time.ZonedDateTime
 import java.util.UUID
@@ -182,7 +182,7 @@ class DataProcessor[F[_]]()(implicit me: MonadError[F, Throwable]) {
   def allBitstreamInfo(
       bitstreamElements: Seq[Elem],
       generationType: GenerationType,
-      potentialCoTitle: Option[String] = None
+      contentObject: Entity
   ): F[Seq[BitStreamInfo]] =
     me.pure {
       bitstreamElements.map { be =>
@@ -203,7 +203,8 @@ class DataProcessor[F[_]]()(implicit me: MonadError[F, Throwable]) {
           Fixity(fixityAlgorithm, fixityValue),
           generationVersion,
           generationType,
-          potentialCoTitle
+          contentObject.title,
+          contentObject.parent
         )
       }
     }

--- a/src/main/scala/uk/gov/nationalarchives/dp/client/DataProcessor.scala
+++ b/src/main/scala/uk/gov/nationalarchives/dp/client/DataProcessor.scala
@@ -5,7 +5,7 @@ import cats.implicits._
 import uk.gov.nationalarchives.dp.client.Client._
 import uk.gov.nationalarchives.dp.client.DataProcessor.EventAction
 import uk.gov.nationalarchives.dp.client.Entities._
-import uk.gov.nationalarchives.dp.client.EntityClient.{ContentObject, _}
+import uk.gov.nationalarchives.dp.client.EntityClient._
 
 import java.time.ZonedDateTime
 import java.util.UUID

--- a/src/main/scala/uk/gov/nationalarchives/dp/client/EntityClient.scala
+++ b/src/main/scala/uk/gov/nationalarchives/dp/client/EntityClient.scala
@@ -469,7 +469,7 @@ object EntityClient {
             allBitstreamUrls <- dataProcessor.allBitstreamUrls(generationElement)
             bitstreamElements <- allBitstreamUrls.map(url => sendXMLApiRequest(url, token, Method.GET)).sequence
             contentObject <- dataProcessor.getEntity(contentObjectRef, contentObjectElement, ContentObject)
-            allBitstreamInfo <- dataProcessor.allBitstreamInfo(bitstreamElements, generationType, contentObject.title)
+            allBitstreamInfo <- dataProcessor.allBitstreamInfo(bitstreamElements, generationType, contentObject)
           } yield allBitstreamInfo
         }.flatSequence
 

--- a/src/test/scala/uk/gov/nationalarchives/dp/client/DataProcessorTest.scala
+++ b/src/test/scala/uk/gov/nationalarchives/dp/client/DataProcessorTest.scala
@@ -18,10 +18,10 @@ abstract class DataProcessorTest[F[_]](implicit cme: MonadError[F, Throwable]) e
 
   def valueFromF[T](value: F[T]): T
 
-  private def generateContentObject(ref: String) = Entity(
+  private def generateContentObject(ref: String, title: Option[String] = None) = Entity(
     Some(ContentObject),
     UUID.fromString(ref),
-    None,
+    title,
     None,
     false,
     Some(ContentObject.entityPath),
@@ -305,7 +305,11 @@ abstract class DataProcessorTest[F[_]](implicit cme: MonadError[F, Throwable]) e
       </BitstreamResponse>
     )
 
-    val generationsF = new DataProcessor[F]().allBitstreamInfo(input, Original, Some("testCoTitle"))
+    val generationsF = new DataProcessor[F]().allBitstreamInfo(
+      input,
+      Original,
+      generateContentObject("ad30d41e-b75c-4195-b569-91e820f430ac", Some("testCoTitle"))
+    )
     val response = valueFromF(generationsF)
 
     response.size should equal(1)
@@ -317,6 +321,7 @@ abstract class DataProcessorTest[F[_]](implicit cme: MonadError[F, Throwable]) e
     response.head.generationVersion should equal(2)
     response.head.generationType should equal(Original)
     response.head.potentialCoTitle should equal(Some("testCoTitle"))
+    response.head.parentRef should equal(Some(UUID.fromString("14e54a24-db26-4c00-852c-f28045e51828")))
   }
 
   "getNextPage" should "return the next page" in {

--- a/src/test/scala/uk/gov/nationalarchives/dp/client/EntityClientTest.scala
+++ b/src/test/scala/uk/gov/nationalarchives/dp/client/EntityClientTest.scala
@@ -513,6 +513,7 @@ abstract class EntityClientTest[F[_], S](preservicaPort: Int, secretsManagerPort
     bitStreamInfo.generationVersion should equal(1)
     bitStreamInfo.generationType should equal(Derived)
     bitStreamInfo.potentialCoTitle should equal(Some("page1File.txt"))
+    bitStreamInfo.parentRef should equal(Some(UUID.fromString("a6771bd9-a4df-47fb-bcc1-982f0b42f7cb")))
 
     checkServerCall(entityUrl)
     checkServerCall(generationsUrl)
@@ -623,6 +624,7 @@ abstract class EntityClientTest[F[_], S](preservicaPort: Int, secretsManagerPort
     bitStreamInfo.head.generationVersion should equal(1)
     bitStreamInfo.head.generationType should equal(Original)
     bitStreamInfo.head.potentialCoTitle should equal(Some("page1File.txt"))
+    bitStreamInfo.head.parentRef should equal(Some(UUID.fromString("a6771bd9-a4df-47fb-bcc1-982f0b42f7cb")))
 
     bitStreamInfo.last.url should equal(s"http://test")
     bitStreamInfo.last.name should equal("test2.txt")
@@ -632,6 +634,7 @@ abstract class EntityClientTest[F[_], S](preservicaPort: Int, secretsManagerPort
     bitStreamInfo.last.generationVersion should equal(2)
     bitStreamInfo.last.generationType should equal(Derived)
     bitStreamInfo.last.potentialCoTitle should equal(Some("page1File.txt"))
+    bitStreamInfo.last.parentRef should equal(Some(UUID.fromString("a6771bd9-a4df-47fb-bcc1-982f0b42f7cb")))
 
     checkServerCall(entityUrl)
     checkServerCall(generationsUrl)


### PR DESCRIPTION
The disaster recovery was making a call to get the bitstreamInfo and to 'getEntity' to get the parentRef, so this commit just adds the parentRef to the bitstreamInfo, since it already calls 'getEntity'.