### PR TITLE
Various fixes for things.

### DIFF
--- a/src/main/scala/uk/gov/nationalarchives/dp/client/DataProcessor.scala
+++ b/src/main/scala/uk/gov/nationalarchives/dp/client/DataProcessor.scala
@@ -114,21 +114,19 @@ class DataProcessor[F[_]]()(using me: MonadError[F, Throwable]) {
     * @return
     *   A `Seq` of String representing the metadata XML or an error if none are found
     */
-  def fragments(metadataResponseElements: Seq[Elem]): F[Seq[String]] = {
+  def fragments(metadataResponseElements: Seq[Elem]): F[Seq[Node]] = {
     val metadataContainerObjects =
-      metadataResponseElements.map(_.flatMap(_.child).toString())
+      (metadataResponseElements \ "MetadataContainer").toList
 
-    val blankMetadataContainerObjects = metadataContainerObjects.filter(_.isBlank)
-
-    blankMetadataContainerObjects match {
-      case Nil => me.pure(metadataContainerObjects)
-      case _ =>
-        me.raiseError(
-          PreservicaClientException(
-            s"Could not be retrieve all 'MetadataContainer' Nodes from:\n${metadataResponseElements.mkString("\n")}"
-          )
+    val blankMetadataContainerObjects = metadataContainerObjects.filter(_.isEmpty)
+    if (metadataContainerObjects.isEmpty || blankMetadataContainerObjects.nonEmpty || metadataContainerObjects.size != metadataResponseElements.size) && metadataResponseElements.nonEmpty
+    then
+      me.raiseError(
+        PreservicaClientException(
+          s"Could not be retrieve all 'MetadataContainer' Nodes from:\n${metadataResponseElements.mkString("\n")}"
         )
-    }
+      )
+    else me.pure(metadataContainerObjects)
   }
 
   /** Gets the text of the first generation element

--- a/src/main/scala/uk/gov/nationalarchives/dp/client/DataProcessor.scala
+++ b/src/main/scala/uk/gov/nationalarchives/dp/client/DataProcessor.scala
@@ -118,8 +118,8 @@ class DataProcessor[F[_]]()(using me: MonadError[F, Throwable]) {
     val metadataContainerObjects =
       (metadataResponseElements \ "MetadataContainer").toList
 
-    val blankMetadataContainerObjects = metadataContainerObjects.filter(_.isEmpty)
-    if (metadataContainerObjects.isEmpty || blankMetadataContainerObjects.nonEmpty || metadataContainerObjects.size != metadataResponseElements.size) && metadataResponseElements.nonEmpty
+    val emptyMetadataContainerObjects = metadataContainerObjects.filter(_.isEmpty)
+    if (metadataContainerObjects.isEmpty || emptyMetadataContainerObjects.nonEmpty || metadataContainerObjects.size != metadataResponseElements.size) && metadataResponseElements.nonEmpty
     then
       me.raiseError(
         PreservicaClientException(

--- a/src/test/scala/uk/gov/nationalarchives/dp/client/DataProcessorTest.scala
+++ b/src/test/scala/uk/gov/nationalarchives/dp/client/DataProcessorTest.scala
@@ -127,8 +127,8 @@ abstract class DataProcessorTest[F[_]](using cme: MonadError[F, Throwable]) exte
     val fragments = valueFromF(fragmentsF)
 
     fragments.size should equal(2)
-    fragments.head.trim should equal(fragmentContainer(1).child(1).toString)
-    fragments.last.trim should equal(fragmentContainer(2).child(1).toString)
+    fragments.head should equal(fragmentContainer(1).child(1))
+    fragments.last should equal(fragmentContainer(2).child(1))
   }
 
   "fragments" should "return an error if there is no content" in {

--- a/src/test/scala/uk/gov/nationalarchives/dp/client/EntityClientTest.scala
+++ b/src/test/scala/uk/gov/nationalarchives/dp/client/EntityClientTest.scala
@@ -724,7 +724,7 @@ abstract class EntityClientTest[F[_], S](preservicaPort: Int, secretsManagerPort
     val entityId = UUID.randomUUID()
     val entity = valueFromF(fromType("IO", entityId, Option("title"), Option("description"), deleted = false))
     val entityUrl = s"/api/entity/v$apiVersion/${entity.path.get}/${entity.ref}"
-    val identifiersUrl = s"/api/entity/v$apiVersion/${entity.path.get}/identifiers"
+    val identifiersUrl = s"/api/entity/v$apiVersion/${entity.path.get}/${entity.ref}/identifiers"
     val fragmentOneUrl = s"/api/entity/v$apiVersion/information-objects/$entityId/metadata/${UUID.randomUUID()}"
     val entityResponse =
       <EntityResponse xmlns={namespaceUrl} xmlns:xip={xipUrl}>
@@ -819,7 +819,7 @@ abstract class EntityClientTest[F[_], S](preservicaPort: Int, secretsManagerPort
     val entityUrl = s"/api/entity/v$apiVersion/${entity.path.get}/${entity.ref}"
     val fragmentOneUrl = s"/api/entity/v$apiVersion/information-objects/$entityId/metadata/${UUID.randomUUID()}"
     val fragmentTwoUrl = s"/api/entity/v$apiVersion/information-objects/$entityId/metadata/${UUID.randomUUID()}"
-    val identifiersUrl = s"/api/entity/v$apiVersion/${entity.path.get}/identifiers"
+    val identifiersUrl = s"/api/entity/v$apiVersion/${entity.path.get}/${entity.ref}/identifiers"
     val entityResponse =
       <EntityResponse xmlns={namespaceUrl} xmlns:xip={xipUrl}>
         <InformationObject>
@@ -936,7 +936,7 @@ abstract class EntityClientTest[F[_], S](preservicaPort: Int, secretsManagerPort
     val entityId = UUID.randomUUID()
     val entity = valueFromF(fromType("IO", entityId, Option("title"), Option("description"), deleted = false))
     val entityUrl = s"/api/entity/v$apiVersion/${entity.path.get}/${entity.ref}"
-    val identifiersUrl = s"/api/entity/v$apiVersion/${entity.path.get}/identifiers"
+    val identifiersUrl = s"/api/entity/v$apiVersion/${entity.path.get}/${entity.ref}/identifiers"
 
     val entityResponse =
       <EntityResponse xmlns={namespaceUrl} xmlns:xip={xipUrl}>
@@ -1001,7 +1001,7 @@ abstract class EntityClientTest[F[_], S](preservicaPort: Int, secretsManagerPort
     val entityId = UUID.randomUUID()
     val entity = valueFromF(fromType("IO", entityId, Option("title"), Option("description"), deleted = false))
     val entityUrl = s"/api/entity/v$apiVersion/${entity.path.get}/${entity.ref}"
-    val identifiersUrl = s"/api/entity/v$apiVersion/${entity.path.get}/identifiers"
+    val identifiersUrl = s"/api/entity/v$apiVersion/${entity.path.get}/${entity.ref}/identifiers"
     val fragmentOneUrl = s"/api/entity/v$apiVersion/information-objects/$entityId/metadata/${UUID.randomUUID()}"
     val fragmentTwoUrl = s"/api/entity/v$apiVersion/information-objects/$entityId/metadata/${UUID.randomUUID()}"
     val entityResponse =


### PR DESCRIPTION
* The call to the /identifiers endpoint wasn't passing in the entity id
* The auth details were hard coded as empty string.
* There was an exception parsing the metadata content from a string. I
  don't know why, the XMl looked well formed but after half a day trying
  to work out what's happening, I gave up and made the fragments() method
  return a Node rather than a string.
* I've updated the tests as well.
