### PR TITLE
DR2-1703 Remove dynamo formatters dependency.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -53,7 +53,6 @@ lazy val commonSettings = Seq(
     awsSecretsManager,
     catsCore,
     circeGeneric,
-    dynamoFormatters,
     scalaCacheCore,
     scalaCacheCaffeine,
     log4Cats,

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -10,7 +10,6 @@ object Dependencies {
   lazy val scalaCacheCore = "com.github.cb372" %% "scalacache-core" % scalaCacheVersion
   lazy val scalaCacheCaffeine = "com.github.cb372" %% "scalacache-caffeine" % scalaCacheVersion
   lazy val scalaXml = "org.scala-lang.modules" %% "scala-xml" % "2.3.0"
-  lazy val dynamoFormatters = "uk.gov.nationalarchives" %% "dynamo-formatters" % "0.0.15"
   lazy val sttpCore = "com.softwaremill.sttp.client3" %% "core" % sttpVersion
   lazy val sttpFs2 = "com.softwaremill.sttp.client3" %% "fs2" % sttpVersion
   lazy val log4Cats = "org.typelevel" %% "log4cats-slf4j" % "2.7.0"

--- a/site-docs/src/main/scala/examples/XmlValidator.scala
+++ b/site-docs/src/main/scala/examples/XmlValidator.scala
@@ -5,10 +5,10 @@ object XmlValidator {
   object XmlValidatorFs2 {
     import cats.effect.IO
     import uk.gov.nationalarchives.dp.client.ValidateXmlAgainstXsd
-    import uk.gov.nationalarchives.dp.client.ValidateXmlAgainstXsd.xipXsdSchemaV6
+    import uk.gov.nationalarchives.dp.client.ValidateXmlAgainstXsd.PreservicaSchema.XipXsdSchemaV6
     import uk.gov.nationalarchives.dp.client.fs2.Fs2Client
 
-    val xmlValidator: ValidateXmlAgainstXsd[IO] = Fs2Client.xmlValidator(xipXsdSchemaV6) // a path to any schema can be passed in
+    val xmlValidator: ValidateXmlAgainstXsd[IO] = Fs2Client.xmlValidator(XipXsdSchemaV6) // a path to any schema can be passed in
     val xmlStringToValidate: String = <XIP xmlns="http://preservica.com/XIP/v6.9">
       <InformationObject>
         <Title>A Test Title</Title>

--- a/src/main/scala/uk/gov/nationalarchives/dp/client/EntityClient.scala
+++ b/src/main/scala/uk/gov/nationalarchives/dp/client/EntityClient.scala
@@ -6,7 +6,6 @@ import cats.implicits.*
 import sttp.capabilities.Streams
 import sttp.client3.*
 import sttp.model.Method
-import uk.gov.nationalarchives.DynamoFormatters.Identifier
 import uk.gov.nationalarchives.dp.client.Client.*
 import uk.gov.nationalarchives.dp.client.DataProcessor.EventAction
 import uk.gov.nationalarchives.dp.client.Entities.{Entity, IdentifierResponse}
@@ -649,6 +648,10 @@ object EntityClient {
     case StructuralObject extends EntityType("structural-objects", "SO")
     case InformationObject extends EntityType("information-objects", "IO")
     case ContentObject extends EntityType("content-objects", "CO")
+
+  /** Represents a Preservica identifier
+    */
+  case class Identifier(identifierName: String, value: String)
 
   /** Represents a Preservica representation tag
     */

--- a/src/test/scala/uk/gov/nationalarchives/dp/client/EntityClientTest.scala
+++ b/src/test/scala/uk/gov/nationalarchives/dp/client/EntityClientTest.scala
@@ -14,7 +14,6 @@ import org.scalatest.prop.Tables.Table
 import org.scalatest.{Assertion, BeforeAndAfterEach}
 import sttp.capabilities.Streams
 import uk.gov.nationalarchives.dp.client.Entities.{Entity, IdentifierResponse, fromType}
-import uk.gov.nationalarchives.DynamoFormatters.Identifier
 import uk.gov.nationalarchives.dp.client.Client.*
 import uk.gov.nationalarchives.dp.client.EntityClient.*
 import uk.gov.nationalarchives.dp.client.EntityClient.EntityType.*


### PR DESCRIPTION
I want to move the dynamo formatters to the monorepo but I can't while
this is using it.

It shouldn't be using it, the worlds of Preservica and Dynamo are
separate and it's only in there for the Identifier case class. There'll
be some mapping between them in dr2-ingest but I can live with that.
