### PR TITLE
DR2-1257 Add update password methods

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -50,7 +50,7 @@ lazy val releaseSettings = Seq(
 lazy val commonSettings = Seq(
   scalaVersion := scala3Version,
   libraryDependencies ++= Seq(
-    awsSecretsManager,
+    secretsManagerClient,
     catsCore,
     circeGeneric,
     scalaCacheCore,

--- a/fs2/src/main/scala/uk/gov/nationalarchives/dp/client/fs2/Fs2Client.scala
+++ b/fs2/src/main/scala/uk/gov/nationalarchives/dp/client/fs2/Fs2Client.scala
@@ -13,11 +13,13 @@ import uk.gov.nationalarchives.dp.client.{
   EntityClient,
   LoggingWrapper,
   ProcessMonitorClient,
+  UserClient,
   ValidateXmlAgainstXsd,
   WorkflowClient
 }
 import uk.gov.nationalarchives.dp.client.Client.ClientConfig
 import uk.gov.nationalarchives.dp.client.ProcessMonitorClient.createProcessMonitorClient
+import uk.gov.nationalarchives.dp.client.UserClient.createUserClient
 import uk.gov.nationalarchives.dp.client.ValidateXmlAgainstXsd.PreservicaSchema
 import uk.gov.nationalarchives.dp.client.WorkflowClient.createWorkflowClient
 
@@ -131,6 +133,17 @@ object Fs2Client:
   ): IO[ProcessMonitorClient[IO]] =
     HttpClientFs2Backend.resource[IO](httpClientOptions(potentialProxyUrl)).use { backend =>
       IO(createProcessMonitorClient(ClientConfig(url, secretName, LoggingWrapper(backend), duration, ssmEndpointUri)))
+    }
+
+  def userClient(
+      url: String,
+      secretName: String,
+      duration: FiniteDuration = 15.minutes,
+      ssmEndpointUri: String = defaultSecretsManagerEndpoint,
+      potentialProxyUrl: Option[URI] = None
+  ): IO[UserClient[IO]] =
+    HttpClientFs2Backend.resource[IO](httpClientOptions(potentialProxyUrl)).use { backend =>
+      IO(createUserClient(ClientConfig(url, secretName, LoggingWrapper(backend), duration, ssmEndpointUri)))
     }
 
   def xmlValidator(schema: PreservicaSchema): ValidateXmlAgainstXsd[IO] = ValidateXmlAgainstXsd[IO](schema)

--- a/fs2/src/test/scala/uk/gov/nationalarchives/dp/client/fs2/Fs2ProcessMonitorClientTest.scala
+++ b/fs2/src/test/scala/uk/gov/nationalarchives/dp/client/fs2/Fs2ProcessMonitorClientTest.scala
@@ -5,8 +5,8 @@ import cats.effect.unsafe.implicits.global
 import uk.gov.nationalarchives.dp.client.fs2.Fs2Client.*
 import uk.gov.nationalarchives.dp.client.{ProcessMonitorClient, ProcessMonitorClientTest}
 
-class Fs2ProcessMonitorClientTest extends ProcessMonitorClientTest[IO](9006, 9008):
+class Fs2ProcessMonitorClientTest extends ProcessMonitorClientTest[IO](9012, 9013):
   override def valueFromF[T](value: IO[T]): T = value.unsafeRunSync()
 
   override def createClient(url: String): IO[ProcessMonitorClient[IO]] =
-    processMonitorClient(url, "secret", zeroSeconds, ssmEndpointUri = "http://localhost:9008")
+    processMonitorClient(url, "secret", zeroSeconds, ssmEndpointUri = "http://localhost:9013")

--- a/fs2/src/test/scala/uk/gov/nationalarchives/dp/client/fs2/Fs2UserClientTest.scala
+++ b/fs2/src/test/scala/uk/gov/nationalarchives/dp/client/fs2/Fs2UserClientTest.scala
@@ -1,0 +1,12 @@
+package uk.gov.nationalarchives.dp.client.fs2
+
+import cats.effect.IO
+import cats.effect.unsafe.implicits.global
+import uk.gov.nationalarchives.dp.client.fs2.Fs2Client.*
+import uk.gov.nationalarchives.dp.client.{UserClient, UserClientTest}
+
+class Fs2UserClientTest extends UserClientTest[IO](9010, 9011):
+  override def valueFromF[T](value: IO[T]): T = value.unsafeRunSync()
+
+  override def createClient(url: String): IO[UserClient[IO]] =
+    userClient(url, "secret", zeroSeconds, ssmEndpointUri = "http://localhost:9011")

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -14,7 +14,7 @@ object Dependencies {
   lazy val sttpFs2 = "com.softwaremill.sttp.client3" %% "fs2" % sttpVersion
   lazy val log4Cats = "org.typelevel" %% "log4cats-slf4j" % "2.7.0"
   lazy val sttpCirce = "com.softwaremill.sttp.client3" %% "circe" % sttpVersion
-  lazy val awsSecretsManager = "software.amazon.awssdk" % "secretsmanager" % "2.26.1"
+  lazy val secretsManagerClient = "uk.gov.nationalarchives" %% "da-secretsmanager-client" % "0.1.66-SNAPSHOT"
   lazy val mockito = "org.scalatestplus" %% "mockito-5-10" % s"$scalaTestVersion.0"
   lazy val wireMock = "com.github.tomakehurst" % "wiremock-jre8" % "2.35.2"
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -14,7 +14,7 @@ object Dependencies {
   lazy val sttpFs2 = "com.softwaremill.sttp.client3" %% "fs2" % sttpVersion
   lazy val log4Cats = "org.typelevel" %% "log4cats-slf4j" % "2.7.0"
   lazy val sttpCirce = "com.softwaremill.sttp.client3" %% "circe" % sttpVersion
-  lazy val secretsManagerClient = "uk.gov.nationalarchives" %% "da-secretsmanager-client" % "0.1.66-SNAPSHOT"
+  lazy val secretsManagerClient = "uk.gov.nationalarchives" %% "da-secretsmanager-client" % "0.1.67"
   lazy val mockito = "org.scalatestplus" %% "mockito-5-10" % s"$scalaTestVersion.0"
   lazy val wireMock = "com.github.tomakehurst" % "wiremock-jre8" % "2.35.2"
 }

--- a/src/main/scala/uk/gov/nationalarchives/dp/client/AdminClient.scala
+++ b/src/main/scala/uk/gov/nationalarchives/dp/client/AdminClient.scala
@@ -66,7 +66,7 @@ object AdminClient {
     */
   def createAdminClient[F[_], S](clientConfig: ClientConfig[F, S])(using
       me: MonadError[F, Throwable],
-      sync: Sync[F]
+      sync: Async[F]
   ): AdminClient[F] = new AdminClient[F] {
     private val apiVersion = 7.0f
     private val client: Client[F, S] = Client(clientConfig)

--- a/src/main/scala/uk/gov/nationalarchives/dp/client/ContentClient.scala
+++ b/src/main/scala/uk/gov/nationalarchives/dp/client/ContentClient.scala
@@ -1,7 +1,7 @@
 package uk.gov.nationalarchives.dp.client
 
 import cats.MonadError
-import cats.effect.Sync
+import cats.effect.Async
 import cats.implicits.*
 import io.circe.{Decoder, Printer}
 import io.circe.generic.auto.*
@@ -65,7 +65,7 @@ object ContentClient:
     */
   def createContentClient[F[_], S](clientConfig: ClientConfig[F, S])(using
       me: MonadError[F, Throwable],
-      sync: Sync[F]
+      sync: Async[F]
   ): ContentClient[F] = new ContentClient[F]:
     case class SearchResponseValue(objectIds: List[String], totalHits: Int)
 

--- a/src/main/scala/uk/gov/nationalarchives/dp/client/EntityClient.scala
+++ b/src/main/scala/uk/gov/nationalarchives/dp/client/EntityClient.scala
@@ -1,7 +1,7 @@
 package uk.gov.nationalarchives.dp.client
 
 import cats.MonadError
-import cats.effect.Sync
+import cats.effect.Async
 import cats.implicits.*
 import sttp.capabilities.Streams
 import sttp.client3.*
@@ -220,7 +220,7 @@ object EntityClient {
     */
   def createEntityClient[F[_], S](clientConfig: ClientConfig[F, S])(using
       me: MonadError[F, Throwable],
-      sync: Sync[F]
+      sync: Async[F]
   ): EntityClient[F, S] = new EntityClient[F, S] {
     val dateFormatter: DateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSSXXX")
     private val apiBaseUrl: String = clientConfig.apiBaseUrl

--- a/src/main/scala/uk/gov/nationalarchives/dp/client/ProcessMonitorClient.scala
+++ b/src/main/scala/uk/gov/nationalarchives/dp/client/ProcessMonitorClient.scala
@@ -1,7 +1,7 @@
 package uk.gov.nationalarchives.dp.client
 
 import cats.MonadError
-import cats.effect.Sync
+import cats.effect.Async
 import cats.implicits.*
 import io.circe.generic.auto.*
 import sttp.client3.*
@@ -53,7 +53,7 @@ object ProcessMonitorClient:
     */
   def createProcessMonitorClient[F[_]](clientConfig: ClientConfig[F, ?])(using
       me: MonadError[F, Throwable],
-      sync: Sync[F]
+      sync: Async[F]
   ): ProcessMonitorClient[F] = new ProcessMonitorClient[F]:
     private val apiBaseUrl: String = clientConfig.apiBaseUrl
     private val client: Client[F, ?] = Client(clientConfig)

--- a/src/main/scala/uk/gov/nationalarchives/dp/client/UserClient.scala
+++ b/src/main/scala/uk/gov/nationalarchives/dp/client/UserClient.scala
@@ -1,0 +1,43 @@
+package uk.gov.nationalarchives.dp.client
+
+import cats.MonadError
+import cats.effect.Async
+import io.circe.Printer
+import uk.gov.nationalarchives.dp.client.Client.ClientConfig
+import sttp.model.Method
+import cats.implicits.*
+import io.circe.syntax.*
+import io.circe.generic.auto.*
+import sttp.client3.IsOption
+import uk.gov.nationalarchives.DASecretsManagerClient.Stage.Pending
+import uk.gov.nationalarchives.dp.client.UserClient.ChangePasswordRequest
+
+trait UserClient[F[_]]:
+  def resetPassword(changePasswordRequest: ChangePasswordRequest): F[Unit]
+
+  def testNewPassword(): F[Unit]
+
+object UserClient:
+
+  case class ChangePasswordRequest(password: String, newPassword: String)
+
+  def createUserClient[F[_]](clientConfig: ClientConfig[F, ?])(using
+      me: MonadError[F, Throwable],
+      sync: Async[F]
+  ): UserClient[F] = new UserClient[F]:
+    val client: Client[F, ?] = Client(clientConfig)
+
+    override def testNewPassword(): F[Unit] = for {
+      authDetails <- client.getAuthDetails(Pending)
+      token <- client.generateToken(authDetails)
+    } yield ()
+
+    override def resetPassword(changePasswordRequest: ChangePasswordRequest): F[Unit] = for {
+      token <- client.getAuthenticationToken
+      _ <- client.sendJsonApiRequest[Option[String]](
+        s"${clientConfig.apiBaseUrl}/api/user/password",
+        token,
+        Method.PUT,
+        changePasswordRequest.asJson.printWith(Printer.noSpaces).some
+      )
+    } yield ()

--- a/src/main/scala/uk/gov/nationalarchives/dp/client/WorkflowClient.scala
+++ b/src/main/scala/uk/gov/nationalarchives/dp/client/WorkflowClient.scala
@@ -1,7 +1,7 @@
 package uk.gov.nationalarchives.dp.client
 
 import cats.MonadError
-import cats.effect.Sync
+import cats.effect.Async
 import cats.implicits.*
 import sttp.client3.*
 import sttp.model.Method
@@ -43,7 +43,7 @@ object WorkflowClient {
     */
   def createWorkflowClient[F[_], S](clientConfig: ClientConfig[F, S])(using
       me: MonadError[F, Throwable],
-      sync: Sync[F]
+      sync: Async[F]
   ): WorkflowClient[F] = new WorkflowClient[F] {
     private val apiBaseUrl: String = clientConfig.apiBaseUrl
     private val client: Client[F, S] = Client(clientConfig)

--- a/src/test/scala/uk/gov/nationalarchives/dp/client/UserClientTest.scala
+++ b/src/test/scala/uk/gov/nationalarchives/dp/client/UserClientTest.scala
@@ -1,0 +1,122 @@
+package uk.gov.nationalarchives.dp.client
+
+import com.github.tomakehurst.wiremock.WireMockServer
+import com.github.tomakehurst.wiremock.client.WireMock.*
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers.*
+import org.scalatest.{Assertion, BeforeAndAfterEach, EitherValues}
+import uk.gov.nationalarchives.dp.client.ProcessMonitorClient.*
+import uk.gov.nationalarchives.dp.client.ProcessMonitorClient.MessageStatus.*
+import io.circe.parser.decode
+import io.circe.generic.auto.*
+import software.amazon.awssdk.services.secretsmanager.model.SecretsManagerException
+import uk.gov.nationalarchives.dp.client.UserClient.ChangePasswordRequest
+
+import java.util.concurrent.TimeUnit
+import scala.concurrent.duration.FiniteDuration
+import scala.jdk.CollectionConverters.*
+
+abstract class UserClientTest[F[_]](preservicaPort: Int, secretsManagerPort: Int)
+    extends AnyFlatSpec
+    with BeforeAndAfterEach
+    with EitherValues:
+
+  case class SecretRequest(SecretId: String, VersionStage: String)
+
+  val zeroSeconds: FiniteDuration = FiniteDuration(0, TimeUnit.SECONDS)
+  val secretsManagerServer = new WireMockServer(secretsManagerPort)
+  val secretsResponse = """{"SecretString":"{\"username\":\"password\"}"}"""
+  val secretsNewPasswordResponse = """{"SecretString":"{\"username\":\"newPassword\"}"}"""
+  val preservicaServer = new WireMockServer(preservicaPort)
+  private val tokenResponse: String = """{"token": "abcde"}"""
+  private val tokenUrl = "/api/accesstoken/login"
+
+  def valueFromF[T](value: F[T]): T
+
+  def createClient(url: String): F[UserClient[F]]
+
+  def testClient: UserClient[F] = valueFromF(createClient(s"http://localhost:$preservicaPort"))
+
+  override def beforeEach(): Unit =
+    preservicaServer.start()
+    preservicaServer.resetAll()
+    secretsManagerServer.resetAll()
+    secretsManagerServer.start()
+    secretsManagerServer.stubFor(
+      post(urlEqualTo("/"))
+        .withRequestBody(equalToJson("{\"SecretId\":\"secret\",\"VersionStage\":\"AWSPENDING\"}"))
+        .willReturn(okJson(secretsNewPasswordResponse))
+    )
+    secretsManagerServer.stubFor(
+      post(urlEqualTo("/"))
+        .withRequestBody(equalToJson("{\"SecretId\":\"secret\",\"VersionStage\":\"AWSCURRENT\"}"))
+        .willReturn(okJson(secretsResponse))
+    )
+    preservicaServer.stubFor(post(urlEqualTo(tokenUrl)).willReturn(ok(tokenResponse)))
+
+  override def afterEach(): Unit =
+    preservicaServer.stop()
+    secretsManagerServer.stop()
+
+  "resetPassword" should s"return an exception if API returns an error" in {
+    val client = testClient
+
+    preservicaServer.stubFor(put(urlEqualTo("/api/user/password")).willReturn(serverError()))
+
+    val error = intercept[PreservicaClientException] {
+      valueFromF(client.resetPassword(ChangePasswordRequest("old", "new")))
+    }
+    error.getMessage should equal(
+      "Status code 500 calling http://localhost:9010/api/user/password with method PUT statusCode: 500, response: "
+    )
+  }
+
+  "resetPassword" should s"pass the correct credentials to the API" in {
+    preservicaServer.stubFor(put(urlEqualTo("/api/user/password")).willReturn(ok()))
+
+    valueFromF(testClient.resetPassword(ChangePasswordRequest("oldPassword", "newPassword")))
+
+    val bodyString = preservicaServer.getAllServeEvents.asScala.head.getRequest.getBodyAsString
+    val request = decode[ChangePasswordRequest](bodyString).value
+
+    request.password should equal("oldPassword")
+    request.newPassword should equal("newPassword")
+  }
+
+  "testNewPassword" should "call secrets manager for the pending secret" in {
+    valueFromF(testClient.testNewPassword())
+    val requestBody = secretsManagerServer.getAllServeEvents.asScala.head.getRequest.getBodyAsString
+    val secretRequest = decode[SecretRequest](requestBody).value
+
+    secretRequest.SecretId should equal("secret")
+    secretRequest.VersionStage should equal("AWSPENDING")
+  }
+
+  "testNewPassword" should "call the Preservica auth url with the pending password" in {
+    valueFromF(testClient.testNewPassword())
+    val body = preservicaServer.getAllServeEvents.asScala.head.getRequest.getBodyAsString
+
+    body should equal("username=username&password=newPassword")
+  }
+
+  "testNewPassword" should "return an error if secrets manager returns an error" in {
+    secretsManagerServer.resetAll()
+    secretsManagerServer.stubFor(post(urlEqualTo("/")).willReturn(serverError()))
+    val ex = intercept[SecretsManagerException] {
+      valueFromF(testClient.testNewPassword())
+    }
+    ex.getMessage should equal(
+      "Service returned HTTP status code 500 (Service: SecretsManager, Status Code: 500, Request ID: null)"
+    )
+  }
+
+  "testNewPassword" should "return an error if Preservica returns an error" in {
+    preservicaServer.resetAll()
+    preservicaServer.stubFor(post(urlEqualTo("/api/accesstoken/login")).willReturn(forbidden()))
+    val ex = intercept[PreservicaClientException] {
+      valueFromF(testClient.testNewPassword())
+    }
+    ex.getMessage should equal(
+      s"Status code 403 calling http://localhost:$preservicaPort/api/accesstoken/login with method POST statusCode: 403, response: "
+    )
+  }


### PR DESCRIPTION
DR2-1257 Add methods to reset and test password changes
    
I've added a method in to reset the password and one to check we can get a token with the new password.

I've also replaced the direct calls to AWS secrets manager SDK with the da-aws-clients one. This meant I had to change all the implicit Sync for Async which is why there's more changes.

