### PR TITLE
Make SerialisedCommand optional

### DIFF
--- a/src/main/resources/XIP-V7.xsd
+++ b/src/main/resources/XIP-V7.xsd
@@ -223,7 +223,7 @@
             <xs:element name="Event" type="tns:EventType"/>
             <xs:element name="Date" type="xs:dateTime" minOccurs="0"/>
             <xs:element name="Entity" type="xs:string"/>
-            <xs:element name="SerialisedCommand" type="xs:string"/>
+            <xs:element name="SerialisedCommand" type="xs:string" minOccurs="0"/>
         </xs:sequence>
         <xs:attribute name="commandType" type="xs:string" use="optional"/>
     </xs:complexType>


### PR DESCRIPTION
It's mandatory here but Preservica don't always send it for some reason.
