### PR TITLE
DR2-1801 Transform XIP output

### DIFF
--- a/src/main/scala/uk/gov/nationalarchives/dp/client/DataProcessor.scala
+++ b/src/main/scala/uk/gov/nationalarchives/dp/client/DataProcessor.scala
@@ -383,18 +383,18 @@ class DataProcessor[F[_]]()(using me: MonadError[F, Throwable]) {
       for {
         linkType <- link.attribute("linkType").flatMap(_.headOption)
         linkDirection <- link.attribute("linkDirection").flatMap(_.headOption)
-        linkRef <- link.attribute("ref").flatMap(_.headOption)
+        refLinks <- link.attribute("ref").flatMap(_.headOption.map(_.toString))
       } yield {
         val entities =
           if linkDirection.text == "To" then
             List(
-              <xip:ToEntity>{linkRef.toString}</xip:ToEntity>
+              <xip:ToEntity>{refLinks}</xip:ToEntity>
           <xip:FromEntity>{ref.toString}</xip:FromEntity>
             )
           else
             List(
               <xip:ToEntity>{ref.toString}</xip:ToEntity>
-            <xip:FromEntity>{linkRef.toString}</xip:FromEntity>
+            <xip:FromEntity>{refLinks}</xip:FromEntity>
             )
 
         <xip:Link xmlns="http://preservica.com/EntityAPI/v7.0" xmlns:xip="http://preservica.com/XIP/v7.0">

--- a/src/main/scala/uk/gov/nationalarchives/dp/client/DataProcessor.scala
+++ b/src/main/scala/uk/gov/nationalarchives/dp/client/DataProcessor.scala
@@ -377,7 +377,33 @@ class DataProcessor[F[_]]()(using me: MonadError[F, Throwable]) {
     * @return
     *   A `Seq` of `Node` containing the links
     */
-  def getEntityLinksXml(elem: Elem): F[Seq[Node]] = me.pure((elem \ "Links" \ "Link"))
+  def getEntityLinksXml(ref: UUID, elem: Elem): F[Seq[Node]] = me.pure {
+    val links = elem \ "Links" \ "Link"
+    links.flatMap { link =>
+      for {
+        linkType <- link.attribute("linkType").flatMap(_.headOption)
+        linkDirection <- link.attribute("linkDirection").flatMap(_.headOption)
+        linkRef <- link.attribute("ref").flatMap(_.headOption)
+      } yield {
+        val entities =
+          if linkDirection.text == "To" then
+            List(
+              <xip:ToEntity>{linkRef.toString}</xip:ToEntity>
+          <xip:FromEntity>{ref.toString}</xip:FromEntity>
+            )
+          else
+            List(
+              <xip:ToEntity>{ref.toString}</xip:ToEntity>
+            <xip:FromEntity>{linkRef.toString}</xip:FromEntity>
+            )
+
+        <xip:Link xmlns="http://preservica.com/EntityAPI/v7.0" xmlns:xip="http://preservica.com/XIP/v7.0">
+          <xip:Type>{linkType.text}</xip:Type>
+          {entities}
+        </xip:Link>
+      }
+    }
+  }
 
   /** Returns a Seq containing multiple [[scala.xml.Node]] XML object objects representing an `EventAction`
     *

--- a/src/main/scala/uk/gov/nationalarchives/dp/client/EntityClient.scala
+++ b/src/main/scala/uk/gov/nationalarchives/dp/client/EntityClient.scala
@@ -374,7 +374,7 @@ object EntityClient {
 
         identifiers <- entityIdentifiersXml(Some(s"$entityUrl/identifiers"), token, Nil)
 
-        entityLinks <- entityLinksXml(uri"$entityUrl/links?$queryParams".toString.some, token, Nil)
+        entityLinks <- entityLinksXml(entity.ref, uri"$entityUrl/links?$queryParams".toString.some, token, Nil)
 
         fragmentUrls <- dataProcessor.fragmentUrls(entityInfo)
         fragmentResponses <- fragmentUrls.map(url => sendXMLApiRequest(url, token, Method.GET)).sequence
@@ -713,6 +713,7 @@ object EntityClient {
         } yield allIdentifiers
 
     private def entityLinksXml(
+        ref: UUID,
         url: Option[String],
         token: String,
         currentCollectionOfEntityLinks: Seq[Node]
@@ -721,9 +722,10 @@ object EntityClient {
       else
         for {
           entityLinksResponseXml <- sendXMLApiRequest(url.get, token, Method.GET)
-          entityLinksXmlBatch <- dataProcessor.getEntityLinksXml(entityLinksResponseXml)
+          entityLinksXmlBatch <- dataProcessor.getEntityLinksXml(ref, entityLinksResponseXml)
           nextPageUrl <- dataProcessor.nextPage(entityLinksResponseXml)
           allEntityLinksXml <- entityLinksXml(
+            ref,
             nextPageUrl,
             token,
             currentCollectionOfEntityLinks ++ entityLinksXmlBatch

--- a/src/test/scala/uk/gov/nationalarchives/dp/client/EntityClientTest.scala
+++ b/src/test/scala/uk/gov/nationalarchives/dp/client/EntityClientTest.scala
@@ -450,19 +450,19 @@ abstract class EntityClientTest[F[_], S](preservicaPort: Int, secretsManagerPort
             <xip:Entity>{entity.ref}</xip:Entity>
           </Identifier>.toString
     )
-    metadata.links.head.toString should equal(
-      <Link linkType="VirtualChild" linkDirection="From" title="Linked folder" ref="758ef5c5-a364-40e5-bd78-e40f72f5a1f0" type="SO" apiId="ccea29cb2c3254e753aa91939e9b5370" xmlns:xip={
-        xipUrl
-      } xmlns={namespaceUrl}>http://localhost:{
-        preservicaPort
-      }/api/entity/v7.0/content-objects/a9e1cae8-ea06-4157-8dd4-82d0525b031c</Link>.toString
+    Utility.trim(metadata.links.head) should equal(
+      Utility.trim(
+        <xip:Link xmlns:xip="http://preservica.com/XIP/v7.0" xmlns="http://preservica.com/EntityAPI/v7.0"><xip:Type>VirtualChild</xip:Type><xip:ToEntity>{
+          entity.ref.toString
+        }</xip:ToEntity><xip:FromEntity>758ef5c5-a364-40e5-bd78-e40f72f5a1f0</xip:FromEntity></xip:Link>
+      )
     )
-    metadata.links.last.toString should equal(
-      <Link linkType="CitedBy" linkDirection="To" title="Source material" ref="866d4c6e-ee51-467a-b7a3-e4b65709cf95" type="IO" apiId="16d02f195c1da0aac0f755ba599d5705" xmlns:xip={
-        xipUrl
-      } xmlns={namespaceUrl}>http://localhost:{
-        preservicaPort
-      }/api/entity/v7.0/content-objects/a9e1cae8-ea06-4157-8dd4-82d0525b031c</Link>.toString
+    Utility.trim(metadata.links.last) should equal(
+      Utility.trim(
+        <xip:Link xmlns:xip="http://preservica.com/XIP/v7.0" xmlns="http://preservica.com/EntityAPI/v7.0"><xip:Type>CitedBy</xip:Type><xip:ToEntity>866d4c6e-ee51-467a-b7a3-e4b65709cf95</xip:ToEntity><xip:FromEntity>{
+          entity.ref.toString
+        }</xip:FromEntity></xip:Link>
+      )
     )
     metadata.metadataNodes.head.toString should equal(
       <Metadata xmlns:xip="http://preservica.com/XIP/v7.0" xmlns="http://preservica.com/EntityAPI/v7.0">
@@ -558,19 +558,19 @@ abstract class EntityClientTest[F[_], S](preservicaPort: Int, secretsManagerPort
             <xip:Entity>{entity.ref}</xip:Entity>
           </Identifier>.toString
     )
-    metadata.links.head.toString should equal(
-      <Link linkType="VirtualChild" linkDirection="From" title="Linked folder" ref="758ef5c5-a364-40e5-bd78-e40f72f5a1f0" type="SO" apiId="ccea29cb2c3254e753aa91939e9b5370" xmlns:xip={
-        xipUrl
-      } xmlns={namespaceUrl}>http://localhost:{
-        preservicaPort
-      }/api/entity/v7.0/information-objects/{entityId}</Link>.toString
+    Utility.trim(metadata.links.head) should equal(
+      Utility.trim(
+        <xip:Link xmlns:xip="http://preservica.com/XIP/v7.0" xmlns="http://preservica.com/EntityAPI/v7.0"><xip:Type>VirtualChild</xip:Type><xip:ToEntity>{
+          entity.ref.toString
+        }</xip:ToEntity><xip:FromEntity>758ef5c5-a364-40e5-bd78-e40f72f5a1f0</xip:FromEntity></xip:Link>
+      )
     )
-    metadata.links.last.toString should equal(
-      <Link linkType="CitedBy" linkDirection="To" title="Source material" ref="866d4c6e-ee51-467a-b7a3-e4b65709cf95" type="IO" apiId="16d02f195c1da0aac0f755ba599d5705" xmlns:xip={
-        xipUrl
-      } xmlns={namespaceUrl}>http://localhost:{
-        preservicaPort
-      }/api/entity/v7.0/information-objects/{entityId}</Link>.toString
+    Utility.trim(metadata.links.last) should equal(
+      Utility.trim(
+        <xip:Link xmlns:xip="http://preservica.com/XIP/v7.0" xmlns="http://preservica.com/EntityAPI/v7.0"><xip:Type>CitedBy</xip:Type><xip:ToEntity>866d4c6e-ee51-467a-b7a3-e4b65709cf95</xip:ToEntity><xip:FromEntity>{
+          entity.ref.toString
+        }</xip:FromEntity></xip:Link>
+      )
     )
     metadata.metadataNodes.head.toString should equal(
       <Metadata xmlns:xip="http://preservica.com/XIP/v7.0" xmlns="http://preservica.com/EntityAPI/v7.0">


### PR DESCRIPTION
Preservica return XMl in this form from their API

```xml
<Link linkType="DerivedFrom" linkDirection="To" title="Title.docx" ref="649b2628-3a89-4eb3-9a50-2a6780ee439b" type="CO" apiId="38f17325c262242c9bdbf877db678e93">https://tna.preservica.com/api/entity/content-objects/649b2628-3a89-4eb3-9a50-2a6780ee439b</Link>
```

What the XIP schema says we need is

```xml
<xip:Link>
    <xip:Type>DerivedFrom</xip:Type>
    <xip:FromEntity>UUID OF CURRENT ENTITY</xip:FromEntity>
    <xip:ToEntity>649b2628-3a89-4eb3-9a50-2a6780ee439b</xip:ToEntity>
</xip:Link>
```

We need to transform the first one into the second one.
