### PR TITLE
Ability to read more than one fixity from preservica

### DIFF
--- a/src/main/scala/uk/gov/nationalarchives/dp/client/Client.scala
+++ b/src/main/scala/uk/gov/nationalarchives/dp/client/Client.scala
@@ -153,8 +153,8 @@ object Client {
     *   The size of the bitstream
     * @param url
     *   The url to download the bitstream
-    * @param fixity
-    *   The fixity of the bitstream
+    * @param fixities
+    *   The list of fixities associated with the bitstream
     * @param generationVersion
     *   The version of the generation
     * @param potentialCoTitle
@@ -166,7 +166,7 @@ object Client {
       name: String,
       fileSize: Long,
       url: String,
-      fixity: Fixity,
+      fixities: List[Fixity],
       generationVersion: Int,
       generationType: GenerationType,
       potentialCoTitle: Option[String],
@@ -197,6 +197,12 @@ object Client {
       secretsManagerEndpointUri: String
   )
 
+  /** Represents fixity for an object
+    * @param algorithm
+    *   Algorithm used to generate hash for this object (e.g. MD5, SHA256 etc.)
+    * @param value
+    *   Hash for this object calculated using the corresponding algorithm
+    */
   case class Fixity(algorithm: String, value: String)
 
   /** Creates a new `Client` instance.

--- a/src/main/scala/uk/gov/nationalarchives/dp/client/DataProcessor.scala
+++ b/src/main/scala/uk/gov/nationalarchives/dp/client/DataProcessor.scala
@@ -210,13 +210,16 @@ class DataProcessor[F[_]]()(using me: MonadError[F, Throwable]) {
         val generationVersion = bitstreamInfoUrlReversed(2).toInt
 
         val bitstreamUrl = (be \\ "AdditionalInformation" \\ "Content").text
-        val fixityAlgorithm = (be \\ "Bitstream" \\ "Fixities" \\ "Fixity" \\ "FixityAlgorithmRef").text
-        val fixityValue = (be \\ "Bitstream" \\ "Fixities" \\ "Fixity" \\ "FixityValue").text
+
+        val fixities = (be \\ "Bitstream" \\ "Fixities" \\ "Fixity").map { eachFixity =>
+          Fixity((eachFixity \ "FixityAlgorithmRef").text, (eachFixity \ "FixityValue").text)
+        }.toList
+
         BitStreamInfo(
           filename,
           fileSize,
           bitstreamUrl,
-          Fixity(fixityAlgorithm, fixityValue),
+          fixities,
           generationVersion,
           generationType,
           contentObject.title,

--- a/src/test/scala/uk/gov/nationalarchives/dp/client/DataProcessorTest.scala
+++ b/src/test/scala/uk/gov/nationalarchives/dp/client/DataProcessorTest.scala
@@ -297,6 +297,10 @@ abstract class DataProcessorTest[F[_]](using cme: MonadError[F, Throwable]) exte
               <xip:FixityAlgorithmRef>SHA1</xip:FixityAlgorithmRef>
               <xip:FixityValue>0c16735b03fe46b931060858e8cd5ca9c5101565</xip:FixityValue>
             </xip:Fixity>
+            <xip:Fixity>
+              <xip:FixityAlgorithmRef>SHA256</xip:FixityAlgorithmRef>
+              <xip:FixityValue>5470f126401c16cd071df3002ab516f176c21a4b0e03df011bad18e200c5f960</xip:FixityValue>
+            </xip:Fixity>
           </xip:Fixities>
         </xip:Bitstream>
         <AdditionalInformation>
@@ -317,8 +321,13 @@ abstract class DataProcessorTest[F[_]](using cme: MonadError[F, Throwable]) exte
     response.head.name should equal("test.text")
     response.head.fileSize should equal(1234)
     response.head.url should equal("http://test")
-    response.head.fixity.algorithm should equal("SHA1")
-    response.head.fixity.value should equal("0c16735b03fe46b931060858e8cd5ca9c5101565")
+    response.head.fixities.size should equal(2)
+    response.head.fixities.find(_.algorithm == "SHA1").get.value should equal(
+      "0c16735b03fe46b931060858e8cd5ca9c5101565"
+    )
+    response.head.fixities.find(_.algorithm == "SHA256").get.value should equal(
+      "5470f126401c16cd071df3002ab516f176c21a4b0e03df011bad18e200c5f960"
+    )
     response.head.generationVersion should equal(2)
     response.head.generationType should equal(Original)
     response.head.potentialCoTitle should equal(Some("testCoTitle"))

--- a/src/test/scala/uk/gov/nationalarchives/dp/client/EntityClientTest.scala
+++ b/src/test/scala/uk/gov/nationalarchives/dp/client/EntityClientTest.scala
@@ -322,8 +322,11 @@ abstract class EntityClientTest[F[_], S](preservicaPort: Int, secretsManagerPort
     )
     bitStreamInfo.head.name should equal("test1.txt")
     bitStreamInfo.head.fileSize should equal(1234)
-    bitStreamInfo.head.fixity.algorithm should equal("SHA1")
-    bitStreamInfo.head.fixity.value should equal("0c16735b03fe46b931060858e8cd5ca9c5101565")
+    bitStreamInfo.head.fixities.size should equal(2)
+    bitStreamInfo.head.fixities.find(_.algorithm == "SHA1").get.value should equal(
+      "0c16735b03fe46b931060858e8cd5ca9c5101565"
+    )
+    bitStreamInfo.head.fixities.find(_.algorithm == "MD5").get.value should equal("4985298cbf6b2b74c522ced8b128ebe3")
     bitStreamInfo.head.generationVersion should equal(1)
     bitStreamInfo.head.generationType should equal(Original)
     bitStreamInfo.head.potentialCoTitle should equal(Some("page1File.txt"))
@@ -334,8 +337,11 @@ abstract class EntityClientTest[F[_], S](preservicaPort: Int, secretsManagerPort
     )
     bitStreamInfo.last.name should equal("test1.txt")
     bitStreamInfo.last.fileSize should equal(1234)
-    bitStreamInfo.last.fixity.algorithm should equal("SHA1")
-    bitStreamInfo.last.fixity.value should equal("0c16735b03fe46b931060858e8cd5ca9c5101565")
+    bitStreamInfo.last.fixities.size should equal(2)
+    bitStreamInfo.last.fixities.find(_.algorithm == "SHA1").get.value should equal(
+      "0c16735b03fe46b931060858e8cd5ca9c5101565"
+    )
+    bitStreamInfo.last.fixities.find(_.algorithm == "MD5").get.value should equal("4985298cbf6b2b74c522ced8b128ebe3")
     bitStreamInfo.last.generationVersion should equal(2)
     bitStreamInfo.last.generationType should equal(Derived)
     bitStreamInfo.last.potentialCoTitle should equal(Some("page1File.txt"))
@@ -506,6 +512,10 @@ abstract class EntityClientTest[F[_], S](preservicaPort: Int, secretsManagerPort
         <xip:Filename>test1.txt</xip:Filename>
         <xip:FileSize>1234</xip:FileSize>
         <xip:Fixities>
+          <xip:Fixity>
+            <xip:FixityAlgorithmRef>MD5</xip:FixityAlgorithmRef>
+            <xip:FixityValue>4985298cbf6b2b74c522ced8b128ebe3</xip:FixityValue>
+          </xip:Fixity>
           <xip:Fixity>
             <xip:FixityAlgorithmRef>SHA1</xip:FixityAlgorithmRef>
             <xip:FixityValue>0c16735b03fe46b931060858e8cd5ca9c5101565</xip:FixityValue>

--- a/src/test/scala/uk/gov/nationalarchives/dp/client/utils/MockPreservicaAPI.scala
+++ b/src/test/scala/uk/gov/nationalarchives/dp/client/utils/MockPreservicaAPI.scala
@@ -346,6 +346,10 @@ object MockPreservicaAPI {
           <xip:FileSize>1234</xip:FileSize>
           <xip:Fixities>
             <xip:Fixity>
+              <xip:FixityAlgorithmRef>MD5</xip:FixityAlgorithmRef>
+              <xip:FixityValue>4985298cbf6b2b74c522ced8b128ebe3</xip:FixityValue>
+            </xip:Fixity>
+            <xip:Fixity>
               <xip:FixityAlgorithmRef>SHA1</xip:FixityAlgorithmRef>
               <xip:FixityValue>0c16735b03fe46b931060858e8cd5ca9c5101565</xip:FixityValue>
             </xip:Fixity>


### PR DESCRIPTION
Preservica client was designed to read only one fixity value. It is now modified to read more than one.
Changes: 
1) BitStreamInfo object changed to have a list of fixities
2) XML reading changed to read all fixities and load them into list
3) corresponding changes in the tests 