### PR TITLE
Set http logging to debug.

### DIFF
--- a/src/main/scala/uk/gov/nationalarchives/dp/client/LoggingWrapper.scala
+++ b/src/main/scala/uk/gov/nationalarchives/dp/client/LoggingWrapper.scala
@@ -20,7 +20,7 @@ private[client] class LoggingWrapper[F[_], P](delegate: SttpBackend[F, P])(using
       logger <- Slf4jLogger.create[F]
       res <- delegate.send(request)
       _ <- logger
-        .info(ctx + ("code" -> res.code.code.toString))(s"Sending $method request to $url. Response ${res.code.code}")
+        .debug(ctx + ("code" -> res.code.code.toString))(s"Sending $method request to $url. Response ${res.code.code}")
     yield res).onError(err =>
       for
         logger <- Slf4jLogger.create[F]


### PR DESCRIPTION
These are the worlds most verbose log messages which makes it very
difficult to find anything.

We can get them back by setting the log level to debug but this will get
rid of them by default.
