### PR TITLE
Get URL from secret

### DIFF
--- a/fs2/src/test/scala/uk/gov/nationalarchives/dp/client/fs2/Fs2ContentClientTest.scala
+++ b/fs2/src/test/scala/uk/gov/nationalarchives/dp/client/fs2/Fs2ContentClientTest.scala
@@ -9,5 +9,5 @@ import uk.gov.nationalarchives.dp.client.{ContentClient, ContentClientTest}
 class Fs2ContentClientTest extends ContentClientTest[IO](9006, 9008):
   override def valueFromF[T](value: IO[T]): T = value.unsafeRunSync()
 
-  override def createClient(url: String): IO[ContentClient[IO]] =
-    contentClient(url, "secret", zeroSeconds, ssmEndpointUri = "http://localhost:9008")
+  override def createClient(): IO[ContentClient[IO]] =
+    contentClient("secret", zeroSeconds, ssmEndpointUri = "http://localhost:9008")

--- a/fs2/src/test/scala/uk/gov/nationalarchives/dp/client/fs2/Fs2EntityClientTest.scala
+++ b/fs2/src/test/scala/uk/gov/nationalarchives/dp/client/fs2/Fs2EntityClientTest.scala
@@ -10,5 +10,5 @@ import uk.gov.nationalarchives.dp.client.{EntityClient, EntityClientTest}
 class Fs2EntityClientTest extends EntityClientTest[IO, Fs2Streams[IO]](9002, 9009, Fs2Streams[IO]):
   override def valueFromF[T](value: IO[T]): T = value.unsafeRunSync()
 
-  override def createClient(url: String): IO[EntityClient[IO, Fs2Streams[IO]]] =
-    entityClient(url, "secret", zeroSeconds, ssmEndpointUri = "http://localhost:9009")
+  override def createClient(): IO[EntityClient[IO, Fs2Streams[IO]]] =
+    entityClient("secret", zeroSeconds, ssmEndpointUri = "http://localhost:9009")

--- a/fs2/src/test/scala/uk/gov/nationalarchives/dp/client/fs2/Fs2ProcessMonitorClientTest.scala
+++ b/fs2/src/test/scala/uk/gov/nationalarchives/dp/client/fs2/Fs2ProcessMonitorClientTest.scala
@@ -8,5 +8,5 @@ import uk.gov.nationalarchives.dp.client.{ProcessMonitorClient, ProcessMonitorCl
 class Fs2ProcessMonitorClientTest extends ProcessMonitorClientTest[IO](9012, 9013):
   override def valueFromF[T](value: IO[T]): T = value.unsafeRunSync()
 
-  override def createClient(url: String): IO[ProcessMonitorClient[IO]] =
-    processMonitorClient(url, "secret", zeroSeconds, ssmEndpointUri = "http://localhost:9013")
+  override def createClient(): IO[ProcessMonitorClient[IO]] =
+    processMonitorClient("secret", zeroSeconds, ssmEndpointUri = "http://localhost:9013")

--- a/fs2/src/test/scala/uk/gov/nationalarchives/dp/client/fs2/Fs2UserClientTest.scala
+++ b/fs2/src/test/scala/uk/gov/nationalarchives/dp/client/fs2/Fs2UserClientTest.scala
@@ -8,5 +8,5 @@ import uk.gov.nationalarchives.dp.client.{UserClient, UserClientTest}
 class Fs2UserClientTest extends UserClientTest[IO](9010, 9011):
   override def valueFromF[T](value: IO[T]): T = value.unsafeRunSync()
 
-  override def createClient(url: String): IO[UserClient[IO]] =
-    userClient(url, "secret", zeroSeconds, ssmEndpointUri = "http://localhost:9011")
+  override def createClient(): IO[UserClient[IO]] =
+    userClient("secret", zeroSeconds, ssmEndpointUri = "http://localhost:9011")

--- a/fs2/src/test/scala/uk/gov/nationalarchives/dp/client/fs2/Fs2WorkflowClientTest.scala
+++ b/fs2/src/test/scala/uk/gov/nationalarchives/dp/client/fs2/Fs2WorkflowClientTest.scala
@@ -8,5 +8,5 @@ import uk.gov.nationalarchives.dp.client.{WorkflowClient, WorkflowClientTest}
 class Fs2WorkflowClientTest extends WorkflowClientTest[IO](9006, 9008):
   override def valueFromF[T](value: IO[T]): T = value.unsafeRunSync()
 
-  override def createClient(url: String): IO[WorkflowClient[IO]] =
-    workflowClient(url, "secret", zeroSeconds, ssmEndpointUri = "http://localhost:9008")
+  override def createClient(): IO[WorkflowClient[IO]] =
+    workflowClient("secret", zeroSeconds, ssmEndpointUri = "http://localhost:9008")

--- a/src/test/scala/uk/gov/nationalarchives/dp/client/ContentClientTest.scala
+++ b/src/test/scala/uk/gov/nationalarchives/dp/client/ContentClientTest.scala
@@ -23,13 +23,14 @@ abstract class ContentClientTest[F[_]](preservicaPort: Int, secretsManagerPort: 
     with EitherValues:
   def valueFromF[T](value: F[T]): T
 
-  def createClient(url: String): F[ContentClient[F]]
+  def createClient(): F[ContentClient[F]]
 
   val zeroSeconds: FiniteDuration = FiniteDuration(0, TimeUnit.SECONDS)
   val preservicaServer = new WireMockServer(preservicaPort)
   val secretsManagerServer = new WireMockServer(secretsManagerPort)
 
-  val secretsResponse = """{"SecretString":"{\"username\":\"test\",\"password\":\"test\"}"}"""
+  val secretsResponse =
+    s"""{"SecretString":"{\\"userName\\":\\"test\\",\\"password\\":\\"test\\",\\"apiUrl\\":\\"http://localhost:$preservicaPort\\"}"}"""
 
   override def beforeEach(): Unit =
     secretsManagerServer.resetAll()
@@ -42,7 +43,7 @@ abstract class ContentClientTest[F[_]](preservicaPort: Int, secretsManagerPort: 
     preservicaServer.stop()
     secretsManagerServer.stop()
 
-  val client: ContentClient[F] = valueFromF(createClient(s"http://localhost:$preservicaPort"))
+  def client: ContentClient[F] = valueFromF(createClient())
 
   val tokenResponse: String = """{"token": "abcde"}"""
   val tokenUrl = "/api/accesstoken/login"

--- a/src/test/scala/uk/gov/nationalarchives/dp/client/EntityClientTest.scala
+++ b/src/test/scala/uk/gov/nationalarchives/dp/client/EntityClientTest.scala
@@ -37,7 +37,8 @@ abstract class EntityClientTest[F[_], S](preservicaPort: Int, secretsManagerPort
 
   val zeroSeconds: FiniteDuration = FiniteDuration(0, TimeUnit.SECONDS)
   val secretsManagerServer = new WireMockServer(secretsManagerPort)
-  val secretsResponse = """{"SecretString":"{\"username\":\"test\",\"password\":\"test\"}"}"""
+  val secretsResponse =
+    s"""{"SecretString":"{\\"userName\\":\\"test\\",\\"password\\":\\"test\\",\\"apiUrl\\":\\"http://localhost:$preservicaPort\\"}"}"""
   val preservicaServer = new WireMockServer(preservicaPort)
 
   val updateRequestPermutations: TableFor2[String, Option[String]] = Table(
@@ -71,9 +72,9 @@ abstract class EntityClientTest[F[_], S](preservicaPort: Int, secretsManagerPort
 
   def valueFromF[T](value: F[T]): T
 
-  def createClient(url: String): F[EntityClient[F, S]]
+  def createClient(): F[EntityClient[F, S]]
 
-  def testClient: EntityClient[F, S] = valueFromF(createClient(s"http://localhost:$preservicaPort"))
+  def testClient: EntityClient[F, S] = valueFromF(createClient())
 
   override def beforeEach(): Unit = {
     preservicaServer.start()

--- a/src/test/scala/uk/gov/nationalarchives/dp/client/ProcessMonitorClientTest.scala
+++ b/src/test/scala/uk/gov/nationalarchives/dp/client/ProcessMonitorClientTest.scala
@@ -21,7 +21,8 @@ abstract class ProcessMonitorClientTest[F[_]](preservicaPort: Int, secretsManage
 
   val zeroSeconds: FiniteDuration = FiniteDuration(0, TimeUnit.SECONDS)
   val secretsManagerServer = new WireMockServer(secretsManagerPort)
-  val secretsResponse = """{"SecretString":"{\"username\":\"test\",\"password\":\"test\"}"}"""
+  val secretsResponse =
+    s"""{"SecretString":"{\\"userName\\":\\"test\\",\\"password\\":\\"test\\",\\"apiUrl\\":\\"http://localhost:$preservicaPort\\"}"}"""
   val preservicaServer = new WireMockServer(preservicaPort)
   private val tokenResponse: String = """{"token": "abcde"}"""
   private val tokenUrl = "/api/accesstoken/login"
@@ -112,9 +113,9 @@ abstract class ProcessMonitorClientTest[F[_]](preservicaPort: Int, secretsManage
 
   def valueFromF[T](value: F[T]): T
 
-  def createClient(url: String): F[ProcessMonitorClient[F]]
+  def createClient(): F[ProcessMonitorClient[F]]
 
-  def testClient: ProcessMonitorClient[F] = valueFromF(createClient(s"http://localhost:$preservicaPort"))
+  def testClient: ProcessMonitorClient[F] = valueFromF(createClient())
 
   override def beforeEach(): Unit =
     preservicaServer.start()

--- a/src/test/scala/uk/gov/nationalarchives/dp/client/UserClientTest.scala
+++ b/src/test/scala/uk/gov/nationalarchives/dp/client/UserClientTest.scala
@@ -23,17 +23,19 @@ abstract class UserClientTest[F[_]](preservicaPort: Int, secretsManagerPort: Int
 
   val zeroSeconds: FiniteDuration = FiniteDuration(0, TimeUnit.SECONDS)
   val secretsManagerServer = new WireMockServer(secretsManagerPort)
-  val secretsResponse = """{"SecretString":"{\"username\":\"password\"}"}"""
-  val secretsNewPasswordResponse = """{"SecretString":"{\"username\":\"newPassword\"}"}"""
+  val secretsResponse =
+    s"""{"SecretString":"{\\"userName\\":\\"test\\",\\"password\\":\\"password\\",\\"apiUrl\\":\\"http://localhost:$preservicaPort\\"}"}"""
+  val secretsNewPasswordResponse =
+    s"""{"SecretString":"{\\"userName\\":\\"test\\",\\"password\\":\\"newPassword\\",\\"apiUrl\\":\\"http://localhost:$preservicaPort\\"}"}"""
   val preservicaServer = new WireMockServer(preservicaPort)
   private val tokenResponse: String = """{"token": "abcde"}"""
   private val tokenUrl = "/api/accesstoken/login"
 
   def valueFromF[T](value: F[T]): T
 
-  def createClient(url: String): F[UserClient[F]]
+  def createClient(): F[UserClient[F]]
 
-  def testClient: UserClient[F] = valueFromF(createClient(s"http://localhost:$preservicaPort"))
+  def testClient: UserClient[F] = valueFromF(createClient())
 
   override def beforeEach(): Unit =
     preservicaServer.start()
@@ -136,7 +138,7 @@ abstract class UserClientTest[F[_]](preservicaPort: Int, secretsManagerPort: Int
     valueFromF(testClient.testNewPassword())
     val body = preservicaServer.getAllServeEvents.asScala.head.getRequest.getBodyAsString
 
-    body should equal("username=username&password=newPassword")
+    body should equal("username=test&password=newPassword")
   }
 
   "testNewPassword" should "return an error if secrets manager returns an error" in {

--- a/src/test/scala/uk/gov/nationalarchives/dp/client/WorkflowClientTest.scala
+++ b/src/test/scala/uk/gov/nationalarchives/dp/client/WorkflowClientTest.scala
@@ -20,15 +20,16 @@ abstract class WorkflowClientTest[F[_]](preservicaPort: Int, secretsManagerPort:
 
   def valueFromF[T](value: F[T]): T
 
-  def createClient(url: String): F[WorkflowClient[F]]
+  def createClient(): F[WorkflowClient[F]]
 
-  def testClient: WorkflowClient[F] = valueFromF(createClient(s"http://localhost:$preservicaPort"))
+  def testClient: WorkflowClient[F] = valueFromF(createClient())
 
   val zeroSeconds: FiniteDuration = FiniteDuration(0, TimeUnit.SECONDS)
 
   val secretsManagerServer = new WireMockServer(secretsManagerPort)
 
-  val secretsResponse = """{"SecretString":"{\"username\":\"test\",\"password\":\"test\"}"}"""
+  val secretsResponse =
+    s"""{"SecretString":"{\\"userName\\":\\"test\\",\\"password\\":\\"test\\",\\"apiUrl\\":\\"http://localhost:$preservicaPort\\"}"}"""
 
   override def beforeEach(): Unit =
     preservicaServer.start()


### PR DESCRIPTION
This was a bit fiddly because the URL is passed in on client creation.

It now calls secrets manager when the client is created and this is then
cached so we shouldn't be making any more secrets manager calls than we
already were.

I've tested this on the ingest lambdas and custodial copy and it works
with some changes
