### PR TITLE
Update to use Central Publisher Portal

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,6 @@
 import sbtrelease.ReleaseStateTransformations.*
 import Dependencies.*
+import sbt.internal.librarymanagement.Publishing.sonaRelease
 
 lazy val scala3Version = "3.7.1"
 
@@ -7,7 +8,11 @@ ThisBuild / scalaVersion := scala3Version
 
 lazy val releaseSettings = Seq(
   useGpgPinentry := true,
-  publishTo := sonatypePublishToBundle.value,
+  publishTo := {
+    val centralSnapshots = "https://central.sonatype.com/repository/maven-snapshots/"
+    if (isSnapshot.value) Some("central-snapshots" at centralSnapshots)
+    else localStaging.value
+  },
   publishMavenStyle := true,
   releaseProcess := Seq[ReleaseStep](
     checkSnapshotDependencies,
@@ -18,7 +23,7 @@ lazy val releaseSettings = Seq(
     commitReleaseVersion,
     tagRelease,
     releaseStepCommand("publishSigned"),
-    releaseStepCommand("sonatypeBundleRelease"),
+    releaseStepCommand(sonaRelease),
     setNextVersion,
     commitNextVersion,
     pushChanges

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,7 +1,6 @@
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.5.5")
 addSbtPlugin("com.github.sbt" % "sbt-release" % "1.4.0")
 resolvers += Resolver.jcenterRepo
-addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.12.2")
 addSbtPlugin("com.github.sbt" % "sbt-pgp" % "2.3.1")
 addSbtPlugin("com.github.sbt" % "sbt-site-paradox" % "1.7.0")
 addSbtPlugin("com.github.sbt" % "sbt-unidoc" % "0.5.0")


### PR DESCRIPTION
The OSSRH APIs we were using to publish the library are end of life now.

We need to move to using the Maven Central Publisher Portal.

The sbt-sonatype plugin we were using doesn't do this because it's now
built into standard sbt.

I've removed the sbt-sonatype plugin and updated the settings based on
these release notes https://github.com/sbt/sbt/releases/tag/v1.11.0

I've tested this and it's working.
