### PR TITLE
Remove circe-generic

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -57,7 +57,6 @@ lazy val commonSettings = Seq(
   libraryDependencies ++= Seq(
     secretsManagerClient,
     catsCore,
-    circeGeneric,
     scalaCacheCore,
     scalaCacheCaffeine,
     log4Cats,

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -5,7 +5,6 @@ object Dependencies {
   private lazy val scalaCacheVersion = "1.0.0-M6"
 
   lazy val catsCore = "org.typelevel" %% "cats-core" % "2.13.0"
-  lazy val circeGeneric = "io.circe" %% "circe-generic" % "0.14.14"
   lazy val scalaTest = "org.scalatest" %% "scalatest" % scalaTestVersion
   lazy val scalaCacheCore = "com.github.cb372" %% "scalacache-core" % scalaCacheVersion
   lazy val scalaCacheCaffeine = "com.github.cb372" %% "scalacache-caffeine" % scalaCacheVersion

--- a/src/main/scala/uk/gov/nationalarchives/dp/client/UserClient.scala
+++ b/src/main/scala/uk/gov/nationalarchives/dp/client/UserClient.scala
@@ -1,12 +1,11 @@
 package uk.gov.nationalarchives.dp.client
 
 import cats.effect.Async
-import io.circe.Printer
+import io.circe.{Decoder, Encoder, Printer}
 import uk.gov.nationalarchives.dp.client.Client.ClientConfig
 import sttp.model.Method
 import cats.implicits.*
 import io.circe.syntax.*
-import io.circe.generic.auto.*
 import sttp.client3.IsOption
 import uk.gov.nationalarchives.DASecretsManagerClient.Stage.Pending
 import uk.gov.nationalarchives.dp.client.UserClient.ResetPasswordRequest
@@ -17,6 +16,9 @@ trait UserClient[F[_]]:
   def testNewPassword(): F[Unit]
 
 object UserClient:
+
+  given Encoder[ResetPasswordRequest] =
+    Encoder.forProduct2("password", "newPassword")(req => (req.password, req.newPassword))
 
   case class ResetPasswordRequest(password: String, newPassword: String) {
     private val currentPasswordTrimmedAndLowerCased = password.toLowerCase().strip()


### PR DESCRIPTION
For some reason I don't understand, any time we pass an implicit decoder
via circe-generic auto derivation, it fails with `NoClassDefFoundError: io/circe/derivation/ConfiguredDecoder$`

If you explicitly create the decoders, it works fine so this is what
I've done here.

It may work with the semi-auto derivation, I haven't tried but this
definitely works so we're going with that.
