### PR TITLE
Add retries with exponential backoff

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -57,6 +57,7 @@ lazy val commonSettings = Seq(
   libraryDependencies ++= Seq(
     secretsManagerClient,
     catsCore,
+    catsRetry,
     scalaCacheCore,
     scalaCacheCaffeine,
     log4Cats,

--- a/fs2/src/main/scala/uk/gov/nationalarchives/dp/client/fs2/Fs2Client.scala
+++ b/fs2/src/main/scala/uk/gov/nationalarchives/dp/client/fs2/Fs2Client.scala
@@ -44,10 +44,11 @@ object Fs2Client:
       secretName: String,
       duration: FiniteDuration = 15.minutes,
       ssmEndpointUri: String = defaultSecretsManagerEndpoint,
-      potentialProxyUrl: Option[URI] = None
+      potentialProxyUrl: Option[URI] = None,
+      retryCount: Int = 5
   ): IO[EntityClient[IO, Fs2Streams[IO]]] =
     HttpClientFs2Backend.resource[IO](httpClientOptions(potentialProxyUrl)).use { backend =>
-      val clientConfig = ClientConfig("", secretName, LoggingWrapper(backend), duration, ssmEndpointUri)
+      val clientConfig = ClientConfig("", secretName, LoggingWrapper(backend), duration, ssmEndpointUri, retryCount)
       Client(clientConfig).getAuthDetails().map { authDetails =>
         createEntityClient(clientConfig.copy(apiBaseUrl = authDetails.apiUrl))
       }
@@ -68,10 +69,11 @@ object Fs2Client:
       secretName: String,
       duration: FiniteDuration = 15.minutes,
       ssmEndpointUri: String = defaultSecretsManagerEndpoint,
-      potentialProxyUrl: Option[URI] = None
+      potentialProxyUrl: Option[URI] = None,
+      retryCount: Int = 5
   ): IO[ContentClient[IO]] =
     HttpClientFs2Backend.resource[IO](httpClientOptions(potentialProxyUrl)).use { backend =>
-      val clientConfig = ClientConfig("", secretName, LoggingWrapper(backend), duration, ssmEndpointUri)
+      val clientConfig = ClientConfig("", secretName, LoggingWrapper(backend), duration, ssmEndpointUri, retryCount)
       Client(clientConfig).getApiUrl.map { apiUrl =>
         createContentClient(clientConfig.copy(apiBaseUrl = apiUrl))
       }
@@ -91,10 +93,11 @@ object Fs2Client:
       secretName: String,
       duration: FiniteDuration = 15.minutes,
       ssmEndpointUri: String = defaultSecretsManagerEndpoint,
-      potentialProxyUrl: Option[URI] = None
+      potentialProxyUrl: Option[URI] = None,
+      retryCount: Int = 5
   ): IO[WorkflowClient[IO]] =
     HttpClientFs2Backend.resource[IO](httpClientOptions(potentialProxyUrl)).use { backend =>
-      val clientConfig = ClientConfig("", secretName, LoggingWrapper(backend), duration, ssmEndpointUri)
+      val clientConfig = ClientConfig("", secretName, LoggingWrapper(backend), duration, ssmEndpointUri, retryCount)
       Client(clientConfig).getApiUrl.map { apiUrl =>
         createWorkflowClient(clientConfig.copy(apiBaseUrl = apiUrl))
       }
@@ -116,10 +119,11 @@ object Fs2Client:
       secretName: String,
       duration: FiniteDuration = 15.minutes,
       ssmEndpointUri: String = defaultSecretsManagerEndpoint,
-      potentialProxyUrl: Option[URI] = None
+      potentialProxyUrl: Option[URI] = None,
+      retryCount: Int = 5
   ): IO[ProcessMonitorClient[IO]] =
     HttpClientFs2Backend.resource[IO](httpClientOptions(potentialProxyUrl)).use { backend =>
-      val clientConfig = ClientConfig("", secretName, LoggingWrapper(backend), duration, ssmEndpointUri)
+      val clientConfig = ClientConfig("", secretName, LoggingWrapper(backend), duration, ssmEndpointUri, retryCount)
       Client(clientConfig).getApiUrl.map { apiUrl =>
         createProcessMonitorClient(clientConfig.copy(apiBaseUrl = apiUrl))
       }
@@ -129,10 +133,11 @@ object Fs2Client:
       secretName: String,
       duration: FiniteDuration = 15.minutes,
       ssmEndpointUri: String = defaultSecretsManagerEndpoint,
-      potentialProxyUrl: Option[URI] = None
+      potentialProxyUrl: Option[URI] = None,
+      retryCount: Int = 5
   ): IO[UserClient[IO]] =
     HttpClientFs2Backend.resource[IO](httpClientOptions(potentialProxyUrl)).use { backend =>
-      val clientConfig = ClientConfig("", secretName, LoggingWrapper(backend), duration, ssmEndpointUri)
+      val clientConfig = ClientConfig("", secretName, LoggingWrapper(backend), duration, ssmEndpointUri, retryCount)
       Client(clientConfig).getApiUrl.map { apiUrl =>
         createUserClient(clientConfig.copy(apiBaseUrl = apiUrl))
       }

--- a/fs2/src/test/scala/uk/gov/nationalarchives/dp/client/fs2/Fs2ContentClientTest.scala
+++ b/fs2/src/test/scala/uk/gov/nationalarchives/dp/client/fs2/Fs2ContentClientTest.scala
@@ -10,4 +10,4 @@ class Fs2ContentClientTest extends ContentClientTest[IO](9006, 9008):
   override def valueFromF[T](value: IO[T]): T = value.unsafeRunSync()
 
   override def createClient(): IO[ContentClient[IO]] =
-    contentClient("secret", zeroSeconds, ssmEndpointUri = "http://localhost:9008")
+    contentClient("secret", zeroSeconds, ssmEndpointUri = "http://localhost:9008", retryCount = 1)

--- a/fs2/src/test/scala/uk/gov/nationalarchives/dp/client/fs2/Fs2EntityClientTest.scala
+++ b/fs2/src/test/scala/uk/gov/nationalarchives/dp/client/fs2/Fs2EntityClientTest.scala
@@ -11,4 +11,4 @@ class Fs2EntityClientTest extends EntityClientTest[IO, Fs2Streams[IO]](9002, 900
   override def valueFromF[T](value: IO[T]): T = value.unsafeRunSync()
 
   override def createClient(): IO[EntityClient[IO, Fs2Streams[IO]]] =
-    entityClient("secret", zeroSeconds, ssmEndpointUri = "http://localhost:9009")
+    entityClient("secret", zeroSeconds, ssmEndpointUri = "http://localhost:9009", retryCount = 1)

--- a/fs2/src/test/scala/uk/gov/nationalarchives/dp/client/fs2/Fs2ProcessMonitorClientTest.scala
+++ b/fs2/src/test/scala/uk/gov/nationalarchives/dp/client/fs2/Fs2ProcessMonitorClientTest.scala
@@ -9,4 +9,4 @@ class Fs2ProcessMonitorClientTest extends ProcessMonitorClientTest[IO](9012, 901
   override def valueFromF[T](value: IO[T]): T = value.unsafeRunSync()
 
   override def createClient(): IO[ProcessMonitorClient[IO]] =
-    processMonitorClient("secret", zeroSeconds, ssmEndpointUri = "http://localhost:9013")
+    processMonitorClient("secret", zeroSeconds, ssmEndpointUri = "http://localhost:9013", retryCount = 1)

--- a/fs2/src/test/scala/uk/gov/nationalarchives/dp/client/fs2/Fs2UserClientTest.scala
+++ b/fs2/src/test/scala/uk/gov/nationalarchives/dp/client/fs2/Fs2UserClientTest.scala
@@ -9,4 +9,4 @@ class Fs2UserClientTest extends UserClientTest[IO](9010, 9011):
   override def valueFromF[T](value: IO[T]): T = value.unsafeRunSync()
 
   override def createClient(): IO[UserClient[IO]] =
-    userClient("secret", zeroSeconds, ssmEndpointUri = "http://localhost:9011")
+    userClient("secret", zeroSeconds, ssmEndpointUri = "http://localhost:9011", retryCount = 1)

--- a/fs2/src/test/scala/uk/gov/nationalarchives/dp/client/fs2/Fs2WorkflowClientTest.scala
+++ b/fs2/src/test/scala/uk/gov/nationalarchives/dp/client/fs2/Fs2WorkflowClientTest.scala
@@ -9,4 +9,4 @@ class Fs2WorkflowClientTest extends WorkflowClientTest[IO](9006, 9008):
   override def valueFromF[T](value: IO[T]): T = value.unsafeRunSync()
 
   override def createClient(): IO[WorkflowClient[IO]] =
-    workflowClient("secret", zeroSeconds, ssmEndpointUri = "http://localhost:9008")
+    workflowClient("secret", zeroSeconds, ssmEndpointUri = "http://localhost:9008", retryCount = 1)

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -4,6 +4,7 @@ object Dependencies {
   private lazy val scalaTestVersion = "3.2.19"
   private lazy val scalaCacheVersion = "1.0.0-M6"
 
+  lazy val catsRetry = "com.github.cb372" %% "cats-retry" % "4.0.0"
   lazy val catsCore = "org.typelevel" %% "cats-core" % "2.13.0"
   lazy val scalaTest = "org.scalatest" %% "scalatest" % scalaTestVersion
   lazy val scalaCacheCore = "com.github.cb372" %% "scalacache-core" % scalaCacheVersion
@@ -13,7 +14,7 @@ object Dependencies {
   lazy val sttpFs2 = "com.softwaremill.sttp.client3" %% "fs2" % sttpVersion
   lazy val log4Cats = "org.typelevel" %% "log4cats-slf4j" % "2.7.1"
   lazy val sttpCirce = "com.softwaremill.sttp.client3" %% "circe" % sttpVersion
-  lazy val secretsManagerClient = "uk.gov.nationalarchives" %% "da-secretsmanager-client" % "0.1.125"
+  lazy val secretsManagerClient = "uk.gov.nationalarchives" %% "da-secretsmanager-client" % "0.1.126"
   lazy val mockito = "org.scalatestplus" %% "mockito-5-10" % "3.2.18.0"
-  lazy val wireMock = "com.github.tomakehurst" % "wiremock-jre8" % "2.35.2"
+  lazy val wireMock = "com.github.tomakehurst" % "wiremock-jre8" % "3.0.1"
 }

--- a/src/test/scala/uk/gov/nationalarchives/dp/client/EntityClientTest.scala
+++ b/src/test/scala/uk/gov/nationalarchives/dp/client/EntityClientTest.scala
@@ -4,9 +4,10 @@ import cats.MonadError
 import cats.effect.Async
 import cats.implicits.catsSyntaxOptionId
 import com.github.tomakehurst.wiremock.WireMockServer
+import com.github.tomakehurst.wiremock.client.MappingBuilder
 import com.github.tomakehurst.wiremock.client.WireMock.*
 import com.github.tomakehurst.wiremock.http.RequestMethod
-import com.github.tomakehurst.wiremock.stubbing.ServeEvent
+import com.github.tomakehurst.wiremock.stubbing.{Scenario, ServeEvent}
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers.*
 import org.scalatest.prop.TableDrivenPropertyChecks.forAll
@@ -101,8 +102,8 @@ abstract class EntityClientTest[F[_]: Async, S](preservicaPort: Int, secretsMana
       case requests: List[String] => requests
       case request: String        => List(request)
     }
-    serverRequestUrls.sorted should equal(
-      (expectedRequestUrlsFlattened ++ List.fill(numOfTokenRequests)(tokenUrl)).sorted
+    serverRequestUrls.sorted.toSet should equal(
+      (expectedRequestUrlsFlattened ++ List.fill(numOfTokenRequests)(tokenUrl)).sorted.toSet
     )
   }
 
@@ -222,7 +223,7 @@ abstract class EntityClientTest[F[_]: Async, S](preservicaPort: Int, secretsMana
     error.getMessage should equal(
       s"Status code 400 calling http://localhost:$preservicaPort/api/entity/v$apiVersion/structural-objects with method POST "
     )
-    verifyServerRequests(List(addEntityUrl))
+    verifyServerRequests(List(addEntityUrl, addEntityUrl))
   }
 
   forAll(updateRequestPermutations) { (title, potentialDescription) =>
@@ -307,7 +308,7 @@ abstract class EntityClientTest[F[_]: Async, S](preservicaPort: Int, secretsMana
     error.getMessage should equal(
       s"Status code 400 calling http://localhost:$preservicaPort/api/entity/v$apiVersion/structural-objects/a9e1cae8-ea06-4157-8dd4-82d0525b031c with method PUT "
     )
-    verifyServerRequests(List(updateEntityUrl))
+    verifyServerRequests(List(updateEntityUrl, updateEntityUrl))
   }
 
   "getBitstreamInfo" should "call the correct API endpoints and return the bitstream info" in {
@@ -792,7 +793,7 @@ abstract class EntityClientTest[F[_]: Async, S](preservicaPort: Int, secretsMana
     response.left.map { err =>
       err.getClass.getSimpleName should equal("PreservicaClientException")
     }
-    verifyServerRequests(List(entitiesUpdatedSinceUrl))
+    verifyServerRequests(List(entitiesUpdatedSinceUrl, entitiesUpdatedSinceUrl))
   }
 
   "entityEventActions" should "return all paginated values in reverse chronological order (most recent EventAction first)" in {
@@ -835,7 +836,7 @@ abstract class EntityClientTest[F[_]: Async, S](preservicaPort: Int, secretsMana
     response.left.map { err =>
       err.getClass.getSimpleName should equal("PreservicaClientException")
     }
-    verifyServerRequests(List(eventActionsUrl))
+    verifyServerRequests(List(eventActionsUrl, eventActionsUrl))
   }
 
   "entityEventActions" should "return an error if the entity path is empty" in {
@@ -958,7 +959,7 @@ abstract class EntityClientTest[F[_]: Async, S](preservicaPort: Int, secretsMana
     response.left.map { err =>
       err.getClass.getSimpleName should equal("PreservicaClientException")
     }
-    verifyServerRequests(List(entitiesByIdentifierUrl))
+    verifyServerRequests(List(entitiesByIdentifierUrl, entitiesByIdentifierUrl))
   }
 
   "addIdentifierForEntity" should s"make a correct request to add an identifier to an Entity" in {
@@ -997,7 +998,7 @@ abstract class EntityClientTest[F[_]: Async, S](preservicaPort: Int, secretsMana
     error.getMessage should equal(
       s"Status code 400 calling http://localhost:$preservicaPort/api/entity/v$apiVersion/structural-objects/${structuralObject.ref}/identifiers with method POST "
     )
-    verifyServerRequests(List(addEntityUrl))
+    verifyServerRequests(List(addEntityUrl, addEntityUrl))
   }
 
   "addIdentifierForEntity" should s"return a message confirmation if the Identifier was added" in {
@@ -1074,7 +1075,46 @@ abstract class EntityClientTest[F[_]: Async, S](preservicaPort: Int, secretsMana
       valueFromF(client.getEntity(id, InformationObject))
     }
     ex.getMessage should be(s"Status code 404 calling $host$getEntitiesUrl with method GET ")
-    verifyServerRequests(List(getEntitiesUrl))
+    verifyServerRequests(List(getEntitiesUrl, getEntitiesUrl))
+  }
+
+  "getEntity" should "return the entity if the first call fails but the second succeeds" in {
+    val host = s"http://localhost:$preservicaPort"
+    val client = testClient
+    val id = UUID.randomUUID()
+    val getEntitiesUrl = s"/api/entity/v$apiVersion/structural-objects/$id"
+    val fullEntityResponse = <EntityResponse>
+      <xip:StructuralObject>
+        <xip:Ref>
+          {id}
+        </xip:Ref>
+        <xip:Title>title.txt</xip:Title>
+        <xip:Description>A description</xip:Description>
+        <xip:SecurityTag>open</xip:SecurityTag>
+      </xip:StructuralObject>
+    </EntityResponse>
+    EntityClientEndpoints(preservicaServer)
+
+    val firstGetMapping: MappingBuilder = get(urlEqualTo(getEntitiesUrl))
+      .inScenario("RetryCall")
+      .whenScenarioStateIs(Scenario.STARTED)
+      .willReturn(notFound())
+      .willSetStateTo("Next call")
+    val secondGetMapping: MappingBuilder = get(urlEqualTo(getEntitiesUrl))
+      .inScenario("RetryCall")
+      .whenScenarioStateIs("Next call")
+      .willReturn(ok(fullEntityResponse.toString))
+
+    preservicaServer.stubFor(firstGetMapping)
+    preservicaServer.stubFor(secondGetMapping)
+
+    val response = valueFromF(client.getEntity(id, StructuralObject))
+
+    response.ref should be(id)
+    response.title should be(Some("title.txt"))
+    response.description should be(Some("A description"))
+    response.securityTag should be(Some(Open))
+    verifyServerRequests(List(getEntitiesUrl, getEntitiesUrl))
   }
 
   "updateEntityIdentifiers" should "not send a request if no identifiers are passed" in {
@@ -1145,7 +1185,7 @@ abstract class EntityClientTest[F[_]: Async, S](preservicaPort: Int, secretsMana
     ex.getMessage should equal(
       s"Status code 500 calling http://localhost:$preservicaPort$updateEntityIdentifiersUrl with method PUT "
     )
-    verifyServerRequests(List(updateEntityIdentifiersUrl))
+    verifyServerRequests(List(updateEntityIdentifiersUrl, updateEntityIdentifiersUrl))
   }
 
   "getEntityIdentifiers" should "return an empty list if there are no identifiers" in {
@@ -1200,7 +1240,7 @@ abstract class EntityClientTest[F[_]: Async, S](preservicaPort: Int, secretsMana
     ex.getMessage should equal(
       s"Status code 500 calling http://localhost:$preservicaPort${endpoints.identifiersUrl} with method GET "
     )
-    verifyServerRequests(List(getEntityIdentifiersUrl))
+    verifyServerRequests(List(getEntityIdentifiersUrl, getEntityIdentifiersUrl))
   }
 
   "getUrlsToIoRepresentations" should "return an empty list if there are no representations" in {
@@ -1262,7 +1302,7 @@ abstract class EntityClientTest[F[_]: Async, S](preservicaPort: Int, secretsMana
     ex.getMessage should equal(
       s"Status code 500 calling http://localhost:$preservicaPort${endpoints.representationsUrl} with method GET "
     )
-    verifyServerRequests(List(ioRepresentationUrls))
+    verifyServerRequests(List(ioRepresentationUrls, ioRepresentationUrls))
   }
 
   "getContentObjectsFromRepresentation" should "return an empty list if there are no representations" in {
@@ -1322,7 +1362,7 @@ abstract class EntityClientTest[F[_]: Async, S](preservicaPort: Int, secretsMana
       valueFromF(client.getContentObjectsFromRepresentation(entity.ref, Preservation, repCount))
     }
     ex.getMessage should equal(s"Status code 500 calling http://localhost:$preservicaPort$url with method GET ")
-    verifyServerRequests(List(ioRepresentationUrls))
+    verifyServerRequests(List(ioRepresentationUrls, ioRepresentationUrls))
   }
 
   "getPreservicaNamespaceVersion" should "extract and return the version, as a float, from a namespace" in {
@@ -1373,7 +1413,7 @@ abstract class EntityClientTest[F[_]: Async, S](preservicaPort: Int, secretsMana
     )
 
     val expectedUrlRequests = stubbedUrls.take(1)
-    verifyServerRequests(List(expectedUrlRequests), expectedUrlRequests.length)
+    verifyServerRequests(List(expectedUrlRequests, expectedUrlRequests), expectedUrlRequests.length)
   }
 
   private def getRequestMade(preservicaServer: WireMockServer) =


### PR DESCRIPTION
This adds retries to the json and xml requests.

There is a configurable number of retries that defaults to 5 and a hard
coded 1 second initial duration for the backoff.

This will retry on errors, i.e. an exception or on a non 200 response.

We were getting issues in the reconciler where the secret was being
rotated but that cache still had the old secret value which had expired
so we were getting 401/403. We're now checking for this and if it
happens, we invalidate both caches so a new secret value and token can
be picked up.
