### PR TITLE
DR2-2419 Add optional end date to updated since.

### DIFF
--- a/site-docs/src/main/paradox/entity/usage/index.md
+++ b/site-docs/src/main/paradox/entity/usage/index.md
@@ -30,7 +30,7 @@ The client exposes 15 methods
   )(url: String, streamFn: stream.BinaryStream => F[T]): F[T]
 
   def entitiesUpdatedSince(
-      dateTime: ZonedDateTime,
+      sinceDateTime: ZonedDateTime,
       startEntry: Int,
       maxEntries: Int = 1000,
       potentialEndDate: Option[ZonedDateTime] = None                          

--- a/site-docs/src/main/paradox/entity/usage/index.md
+++ b/site-docs/src/main/paradox/entity/usage/index.md
@@ -32,7 +32,8 @@ The client exposes 15 methods
   def entitiesUpdatedSince(
       dateTime: ZonedDateTime,
       startEntry: Int,
-      maxEntries: Int = 1000
+      maxEntries: Int = 1000,
+      potentialEndDate: Option[ZonedDateTime] = None                          
   ): F[Seq[Entity]]
 
   def entityEventActions(
@@ -152,7 +153,7 @@ The client exposes 15 methods
 * Passes a stream of the response to the function provided by the second argument.
 
 ### entitiesUpdatedSince
-* Calls the `updated-since` endpoint using the parameters in the arguments.
+* Calls the `updated-since` endpoint using the parameters in the arguments. Has an optional end date which won't return requests newer than that date if provided.
 * Converts the response to `Seq[Entity]` and returns
 
 ### entityEventActions

--- a/src/main/scala/uk/gov/nationalarchives/dp/client/Client.scala
+++ b/src/main/scala/uk/gov/nationalarchives/dp/client/Client.scala
@@ -120,6 +120,7 @@ private[client] class Client[F[_], S](clientConfig: ClientConfig[F, S])(using
       val request = basicRequest
         .headers(Map("Preservica-Access-Token" -> token, "Content-Type" -> "application/xml"))
         .method(method, apiUri)
+        .readTimeout(Duration.Inf)
         .response(asXml)
       val requestWithBody = potentialRequestBody.map(request.body(_)).getOrElse(request)
       backend.send(requestWithBody)
@@ -137,6 +138,7 @@ private[client] class Client[F[_], S](clientConfig: ClientConfig[F, S])(using
       val request = basicRequest
         .headers(Map("Preservica-Access-Token" -> token, "Content-Type" -> "application/json;charset=UTF-8"))
         .method(method, apiUri)
+        .readTimeout(Duration.Inf)
         .response(asJson[R])
       val requestWithBody: RequestT[Identity, Either[ResponseException[String, circe.Error], R], Any] =
         requestBody.map(request.body(_)).getOrElse(request)

--- a/src/main/scala/uk/gov/nationalarchives/dp/client/EntityClient.scala
+++ b/src/main/scala/uk/gov/nationalarchives/dp/client/EntityClient.scala
@@ -148,17 +148,19 @@ trait EntityClient[F[_], S] {
 
   /** Returns any entity updated since the provided dateTime
     *
-    * @param dateTime
+    * @param sinceDateTime
     *   The date and time to pass to the API
     * @param startEntry
     *   The entry to start from. Used for pagination
     * @param maxEntries
     *   The maximum number of entries to return. Defaults to 1000
+    * @param potentialEndDate
+    *   If provided, no entities updated after this date will be returned
     * @return
     *   A `Seq` of [[Entities.Entity]] wrapped in the F effect
     */
   def entitiesUpdatedSince(
-      dateTime: ZonedDateTime,
+      sinceDateTime: ZonedDateTime,
       startEntry: Int,
       maxEntries: Int = 1000,
       potentialEndDate: Option[ZonedDateTime] = None
@@ -450,12 +452,12 @@ object EntityClient {
       }
 
       override def entitiesUpdatedSince(
-          dateTime: ZonedDateTime,
+          sinceDateTime: ZonedDateTime,
           startEntry: Int,
           maxEntries: Int = 1000,
           potentialEndDate: Option[ZonedDateTime] = None
       ): F[Seq[Entity]] = {
-        val dateString = dateTime.format(dateFormatter)
+        val dateString = sinceDateTime.format(dateFormatter)
         val endDateParams =
           potentialEndDate.map(endDate => Map("endDate" -> endDate.format(dateFormatter))).getOrElse(Map())
         val queryParams = Map("date" -> dateString, "max" -> maxEntries, "start" -> startEntry) ++ endDateParams

--- a/src/main/scala/uk/gov/nationalarchives/dp/client/EntityClient.scala
+++ b/src/main/scala/uk/gov/nationalarchives/dp/client/EntityClient.scala
@@ -160,7 +160,8 @@ trait EntityClient[F[_], S] {
   def entitiesUpdatedSince(
       dateTime: ZonedDateTime,
       startEntry: Int,
-      maxEntries: Int = 1000
+      maxEntries: Int = 1000,
+      potentialEndDate: Option[ZonedDateTime] = None
   ): F[Seq[Entity]]
 
   /** Returns a list of event actions for an entity
@@ -451,10 +452,13 @@ object EntityClient {
       override def entitiesUpdatedSince(
           dateTime: ZonedDateTime,
           startEntry: Int,
-          maxEntries: Int = 1000
+          maxEntries: Int = 1000,
+          potentialEndDate: Option[ZonedDateTime] = None
       ): F[Seq[Entity]] = {
         val dateString = dateTime.format(dateFormatter)
-        val queryParams = Map("date" -> dateString, "max" -> maxEntries, "start" -> startEntry)
+        val endDateParams =
+          potentialEndDate.map(endDate => Map("endDate" -> endDate.format(dateFormatter))).getOrElse(Map())
+        val queryParams = Map("date" -> dateString, "max" -> maxEntries, "start" -> startEntry) ++ endDateParams
         val url = uri"$apiUrl/entities/updated-since?$queryParams"
         for {
           updatedEntities <- getEntities(url.toString)

--- a/src/test/scala/uk/gov/nationalarchives/dp/client/EntityClientTest.scala
+++ b/src/test/scala/uk/gov/nationalarchives/dp/client/EntityClientTest.scala
@@ -771,6 +771,25 @@ abstract class EntityClientTest[F[_]: Async, S](preservicaPort: Int, secretsMana
     verifyServerRequests(List(entitiesUpdatedSinceUrl))
   }
 
+  "entitiesUpdatedSince" should "return an entity if the entity is before the end date specified" in {
+    val date = ZonedDateTime.of(2023, 4, 25, 0, 0, 0, 0, ZoneId.of("UTC"))
+    val potentialEndDate = Option(ZonedDateTime.of(2024, 4, 25, 0, 0, 0, 0, ZoneId.of("UTC")))
+    val entitiesUpdatedSinceUrl =
+      EntityClientEndpoints(preservicaServer).stubEntitiesUpdatedSince(date, potentialEndDate = potentialEndDate)
+
+    val client = testClient
+    val response = valueFromF(client.entitiesUpdatedSince(date, 0, potentialEndDate = potentialEndDate))
+
+    val expectedEntity = response.head
+
+    expectedEntity.ref.toString should equal("8a8b1582-aa5f-4eb0-9c5d-2c16049fcb91")
+    expectedEntity.path.get should equal("information-objects")
+    expectedEntity.title.get should be("page1File.txt")
+    expectedEntity.deleted should be(false)
+
+    verifyServerRequests(List(entitiesUpdatedSinceUrl))
+  }
+
   "entitiesUpdatedSince" should "return an empty list if none have been updated" in {
     val date = ZonedDateTime.of(2023, 4, 25, 0, 0, 0, 0, ZoneId.of("UTC"))
     val entitiesUpdatedSinceUrl =


### PR DESCRIPTION
This will be used for the CC reconciler to make sure we don't pick up
things that come into the OCFL repo after we've got the list of OCFL
files as this leads to false positives.

I've also disabled the timeouts on the http requests as some requests
take a long time if Preservica is busy. There's a slight chance that
this will lock up the process but it seems unlikely.
