### PR TITLE
DR2-2422 Only retry on errors

### DIFF
--- a/src/main/scala/uk/gov/nationalarchives/dp/client/Client.scala
+++ b/src/main/scala/uk/gov/nationalarchives/dp/client/Client.scala
@@ -100,7 +100,7 @@ private[client] class Client[F[_], S](clientConfig: ClientConfig[F, S])(using
                 caffeineCache.removeAll >> authDetailsCaffeineCache.removeAll
               }
               .as(HandlerDecision.Continue)
-          case Right(code) if code != StatusCode.Ok =>
+          case Right(code) if code.isClientError || code.isServerError =>
             Logger[F].warn(s"$retryMessage ${code.code} response").as(HandlerDecision.Continue)
           case _ => Async[F].pure(HandlerDecision.Stop)
         }


### PR DESCRIPTION
This was retrying on anything that isn't a 200.
The start workflow call returns 201 so 5 start workflow calls were being
made which started 5 workflows which created 5 assets.
This is bad.
