### PR TITLE
DR2-2714 Remove reusable workflow

### DIFF
--- a/.github/scripts/send_message.py
+++ b/.github/scripts/send_message.py
@@ -1,0 +1,12 @@
+import boto3
+import json
+import os
+
+eventbridge = boto3.client("events", region_name="eu-west-2")
+
+slack_message = os.environ["MESSAGE"]
+detail = json.dumps({"slackMessage": slack_message})
+eventbridge.put_events(
+    Entries=[{'Source': 'DR2TerraformDeploy', 'DetailType': 'DR2DevMessage', 'Detail': detail}]
+)
+

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,4 +11,4 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - run: gh workflow run deploy.yml
         env:
-          GITHUB_TOKEN: ${{ secrets.WORKFLOW_TOKEN }}
+          GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - uses: sbt/setup-sbt@a627500d27445f8c5021755a439829b6e78e3358 # v1.1.15
+      - uses: sbt/setup-sbt@6bec67c98f542b9e17369bfca0ec822ac1363194 # v1.1.19
       - uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 # v6.0.0
         with:
           role-to-assume: arn:aws:iam::${{ secrets.MANAGEMENT_ACCOUNT }}:role/mgmt-library-put-events-role

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,18 +1,51 @@
 name: DP Deploy Preservica Client
 on:
   workflow_dispatch:
+permissions:
+  id-token: write
+  contents: write
+  pull-requests: write
+env:
+  BRANCH_NAME: version-bump-${{ github.run_id }}${{ github.run_attempt }}
 jobs:
   deploy:
-    uses: nationalarchives/tdr-github-actions/.github/workflows/sbt_release.yml@13faff54c193651ee30482ebdf01e083c8b14203
-    with:
-      library-name: "Preservica Client"
-    secrets:
-      WORKFLOW_PAT: ${{ secrets.WORKFLOW_TOKEN }}
-      SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
-      SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
-      SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
-      GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
-      GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: sbt/setup-sbt@a627500d27445f8c5021755a439829b6e78e3358 # v1.1.15
+      - uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 # v6.0.0
+        with:
+          role-to-assume: arn:aws:iam::${{ secrets.MANAGEMENT_ACCOUNT }}:role/mgmt-library-put-events-role
+          aws-region: eu-west-2
+          role-session-name: PreservicaClientDeploySendMessage
+      - name: Import GPG key
+        uses: crazy-max/ghaction-import-gpg@2dc316deee8e90f13e1a351ab510b4d5bc0c82cd # v7.0.0
+        with:
+          git_user_signingkey: true
+          git_commit_gpgsign: true
+          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
+          passphrase: ${{ secrets.GPG_PASSPHRASE }}
+      - run: |
+          git config --global user.email 181243999+tna-da-bot@users.noreply.github.com
+          git config --global user.name tna-da-bot
+          git checkout -b $BRANCH_NAME
+          git push -u origin $BRANCH_NAME
+          sbt '+release with-defaults'
+        env:
+          SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
+          SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
+      - name: Create Pull Request
+        run: gh pr create --fill --label 'Version bump'
+        env:
+          GH_TOKEN: ${{ secrets.WORKFLOW_TOKEN }}
+      - run: pip install boto3
+      - if: failure()
+        run: python .github/scripts/send_message.py
+        env:
+          MESSAGE: ":warning: Build failed for Preservica client <https://github.com/nationalarchives/dr2-preservica-client/actions/runs/${{ github.run_id }}|View the failed workflow>"
+      - run: python .github/scripts/send_message.py
+        env:
+          MESSAGE: ":white_check_mark: Preservica client has been published"
   build-docs:
     runs-on: ubuntu-latest
     steps:
@@ -28,8 +61,8 @@ jobs:
           git checkout gh-pages
           rm -rf docs
           mkdir docs && cp -r site-docs/target/site/* docs
-          git add docs
-          git commit -m "Update site documentation"
-          git push -u origin gh-pages
+          git add docs | true
+          git commit -m "Update site documentation"  | true
+          git push -u origin gh-pages  | true
         env:
-          GITHUB_TOKEN: ${{ secrets.WORKFLOW_TOKEN }}
+          GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/scala-steward.yml
+++ b/.github/workflows/scala-steward.yml
@@ -1,0 +1,29 @@
+name: Run Scala Steward
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '15 8 */3 * *'
+permissions:
+  contents: write
+  pull-requests: write
+jobs:
+  scala-steward:
+    runs-on: ubuntu-latest
+    name: Launch Scala Steward
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Import GPG key
+        id: import_gpg
+        uses: crazy-max/ghaction-import-gpg@2dc316deee8e90f13e1a351ab510b4d5bc0c82cd # v7.0.0
+        with:
+          git_user_signingkey: true
+          git_commit_gpgsign: true
+          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
+          passphrase: ${{ secrets.GPG_PASSPHRASE }}
+      - name: Launch Scala Steward
+        uses: scala-steward-org/scala-steward-action@df2a4cec1721d0b48be3e1d1f0acdf7543ea0fb4 # v2.84.0
+        with:
+          sign-commits: true
+          signing-key: ${{ secrets.GPG_KEY_ID }}
+          author-email: ${{ steps.import_gpg.outputs.email }}
+          author-name: ${{ steps.import_gpg.outputs.name }}

--- a/site-docs/src/main/paradox/index.md
+++ b/site-docs/src/main/paradox/index.md
@@ -14,8 +14,6 @@ A @ref:[process monitor client](processmonitor/usage/index.md) which provides a 
 
 It also provides an @ref:[XML Validator](xmlvalidator/usage/index.md) which provides a method that validates XML against an XSD schema.
 
-View the [Scaladoc](api/uk/gov/nationalarchives/dp/client/index.html)
-
 @@@ index
 
 * [Entity Client Usage](entity/usage/index.md)

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "0.0.164-SNAPSHOT"
+ThisBuild / version := "0.0.165-SNAPSHOT"


### PR DESCRIPTION
We were using the tdr one which is fine but I don't want things to break
if they change anything so I've done this.

I've also removed all references to WORKFLOW_TOKEN apart from one. I
need that to create the pull request otherwise the tests don't trigger
after the PR is created.
