### PR TITLE
DR2-2824 Remove initial secrets manager cache.

### DIFF
--- a/fs2/src/main/scala/uk/gov/nationalarchives/dp/client/fs2/Fs2Client.scala
+++ b/fs2/src/main/scala/uk/gov/nationalarchives/dp/client/fs2/Fs2Client.scala
@@ -7,7 +7,6 @@ import sttp.client4.httpclient.fs2.HttpClientFs2Backend
 import uk.gov.nationalarchives.dp.client.EntityClient.*
 import uk.gov.nationalarchives.dp.client.ContentClient.createContentClient
 import uk.gov.nationalarchives.dp.client.{
-  Client,
   ContentClient,
   EntityClient,
   ProcessMonitorClient,
@@ -47,10 +46,8 @@ object Fs2Client:
       retryCount: Int = 5
   ): IO[EntityClient[IO, Fs2Streams[IO]]] =
     HttpClientFs2Backend.resource[IO](httpClientOptions(potentialProxyUrl)).use { backend =>
-      val clientConfig = ClientConfig("", secretName, backend, duration, ssmEndpointUri, retryCount)
-      Client(clientConfig).getAuthDetails().map { authDetails =>
-        createEntityClient(clientConfig.copy(apiBaseUrl = authDetails.apiUrl))
-      }
+      val clientConfig = ClientConfig(secretName, backend, duration, ssmEndpointUri, retryCount)
+      IO(createEntityClient(clientConfig))
     }
 
   /** Creates a content client
@@ -72,10 +69,8 @@ object Fs2Client:
       retryCount: Int = 5
   ): IO[ContentClient[IO]] =
     HttpClientFs2Backend.resource[IO](httpClientOptions(potentialProxyUrl)).use { backend =>
-      val clientConfig = ClientConfig("", secretName, backend, duration, ssmEndpointUri, retryCount)
-      Client(clientConfig).getApiUrl.map { apiUrl =>
-        createContentClient(clientConfig.copy(apiBaseUrl = apiUrl))
-      }
+      val clientConfig = ClientConfig(secretName, backend, duration, ssmEndpointUri, retryCount)
+      IO(createContentClient(clientConfig))
     }
 
   /** Creates a workflow client
@@ -96,10 +91,8 @@ object Fs2Client:
       retryCount: Int = 5
   ): IO[WorkflowClient[IO]] =
     HttpClientFs2Backend.resource[IO](httpClientOptions(potentialProxyUrl)).use { backend =>
-      val clientConfig = ClientConfig("", secretName, backend, duration, ssmEndpointUri, retryCount)
-      Client(clientConfig).getApiUrl.map { apiUrl =>
-        createWorkflowClient(clientConfig.copy(apiBaseUrl = apiUrl))
-      }
+      val clientConfig = ClientConfig(secretName, backend, duration, ssmEndpointUri, retryCount)
+      IO(createWorkflowClient(clientConfig))
 
     }
 
@@ -112,7 +105,7 @@ object Fs2Client:
     * @param ssmEndpointUri
     *   The endpoint of secrets manager to use
     * @return
-    *   A a process monitor client
+    *   A process monitor client
     */
   def processMonitorClient(
       secretName: String,
@@ -122,10 +115,8 @@ object Fs2Client:
       retryCount: Int = 5
   ): IO[ProcessMonitorClient[IO]] =
     HttpClientFs2Backend.resource[IO](httpClientOptions(potentialProxyUrl)).use { backend =>
-      val clientConfig = ClientConfig("", secretName, backend, duration, ssmEndpointUri, retryCount)
-      Client(clientConfig).getApiUrl.map { apiUrl =>
-        createProcessMonitorClient(clientConfig.copy(apiBaseUrl = apiUrl))
-      }
+      val clientConfig = ClientConfig(secretName, backend, duration, ssmEndpointUri, retryCount)
+      IO(createProcessMonitorClient(clientConfig))
     }
 
   def userClient(
@@ -136,10 +127,8 @@ object Fs2Client:
       retryCount: Int = 5
   ): IO[UserClient[IO]] =
     HttpClientFs2Backend.resource[IO](httpClientOptions(potentialProxyUrl)).use { backend =>
-      val clientConfig = ClientConfig("", secretName, backend, duration, ssmEndpointUri, retryCount)
-      Client(clientConfig).getApiUrl.map { apiUrl =>
-        createUserClient(clientConfig.copy(apiBaseUrl = apiUrl))
-      }
+      val clientConfig = ClientConfig(secretName, backend, duration, ssmEndpointUri, retryCount)
+      IO(createUserClient(clientConfig))
 
     }
 

--- a/src/main/scala/uk/gov/nationalarchives/dp/client/Client.scala
+++ b/src/main/scala/uk/gov/nationalarchives/dp/client/Client.scala
@@ -47,15 +47,10 @@ import scala.xml.{Elem, XML}
 private[client] class Client[F[_], S](clientConfig: ClientConfig[F, S])(using
     async: Async[F]
 ) {
-  private val underlying: CCache[String, Entry[String]] =
-    Caffeine.newBuilder().maximumSize(10000L).build[String, Entry[String]]
-  private val underlyingAuthDetails: CCache[String, Entry[AuthDetails]] =
-    Caffeine.newBuilder().maximumSize(10000L).build[String, Entry[AuthDetails]]
+  private val underlying: CCache[String, Entry[TokenDetails]] =
+    Caffeine.newBuilder().maximumSize(10000L).build[String, Entry[TokenDetails]]
 
-  given caffeineCache: Cache[F, String, String] = CaffeineCache[F, String, String](underlying)
-
-  given authDetailsCaffeineCache: Cache[F, String, AuthDetails] =
-    CaffeineCache[F, String, AuthDetails](underlyingAuthDetails)
+  given caffeineCache: Cache[F, String, TokenDetails] = CaffeineCache[F, String, TokenDetails](underlying)
 
   val secretName: String = clientConfig.secretName
   private[client] val asXml: ResponseAs[Either[String, Elem]] =
@@ -67,8 +62,7 @@ private[client] class Client[F[_], S](clientConfig: ClientConfig[F, S])(using
     LogConfig(logRequestHeaders = false, logResponseHeaders = false, beforeRequestSendLogLevel = Trace)
   private[client] val backend: WebSocketStreamBackend[F, S] = Slf4jLoggingBackend(clientConfig.backend, logConfig)
   private val duration: FiniteDuration = clientConfig.duration
-  private[client] val apiBaseUrl: String = clientConfig.apiBaseUrl
-  private val loginEndpointUri = uri"$apiBaseUrl/api/accesstoken/login"
+  private def loginEndpointUri(apiBaseUrl: String) = uri"$apiBaseUrl/api/accesstoken/login"
   private val secretsManagerEndpointUri: String = clientConfig.secretsManagerEndpointUri
 
   given Decoder[AuthDetails] = (c: HCursor) =>
@@ -102,7 +96,7 @@ private[client] class Client[F[_], S](clientConfig: ClientConfig[F, S])(using
             Logger[F]
               .warn(s"$retryMessage unauthorised response ${code.code}. Invalidating cache")
               .flatMap { _ =>
-                caffeineCache.removeAll >> authDetailsCaffeineCache.removeAll
+                caffeineCache.removeAll
               }
               .as(HandlerDecision.Continue)
           case Right(code) if code.isClientError || code.isServerError =>
@@ -115,22 +109,28 @@ private[client] class Client[F[_], S](clientConfig: ClientConfig[F, S])(using
     }
   }
 
+  private def createApiUri(url: String, apiUrl: String) =
+    if uri"$url".host.isDefined then uri"$url" else uri"${s"$apiUrl/$url"}"
+
   private[client] def sendXMLApiRequest(
       url: String,
       method: Method,
       potentialRequestBody: Option[String] = None
   ) = {
-    val apiUri = uri"$url"
-    val response = getAuthenticationToken.flatMap { token =>
-      val request = basicRequest
-        .headers(Map("Preservica-Access-Token" -> token, "Content-Type" -> "application/xml"))
-        .method(method, apiUri)
-        .readTimeout(Duration.Inf)
-        .response(asXml)
-      val requestWithBody = potentialRequestBody.map(request.body(_)).getOrElse(request)
-      backend.send(requestWithBody)
-    }
-    retrySend(method, apiUri, response)
+    getAuthenticationToken
+      .flatMap { tokenDetails =>
+        val apiUri = createApiUri(url, tokenDetails.apiUrl)
+        val request = basicRequest
+          .headers(Map("Preservica-Access-Token" -> tokenDetails.token, "Content-Type" -> "application/xml"))
+          .method(method, apiUri)
+          .readTimeout(Duration.Inf)
+          .response(asXml)
+        val requestWithBody = potentialRequestBody.map(request.body(_)).getOrElse(request)
+        Async[F].blocking((apiUri, backend.send(requestWithBody)))
+      }
+      .flatMap { case (apiUri, response) =>
+        retrySend(method, apiUri, response)
+      }
   }
 
   private[client] def sendJsonApiRequest[R: IsOption](
@@ -138,53 +138,56 @@ private[client] class Client[F[_], S](clientConfig: ClientConfig[F, S])(using
       method: Method,
       requestBody: Option[String] = None
   )(using decoder: Decoder[R]): F[R] = {
-    val apiUri = uri"$url"
-    val response = getAuthenticationToken.flatMap { token =>
-      val request = basicRequest
-        .headers(Map("Preservica-Access-Token" -> token, "Content-Type" -> "application/json;charset=UTF-8"))
-        .method(method, apiUri)
-        .readTimeout(Duration.Inf)
-        .response(asJson[R])
-      val requestWithBody: Request[Either[ResponseException[String], R]] =
-        requestBody.map(request.body(_)).getOrElse(request)
-      backend.send(requestWithBody)
-    }
-    retrySend(method, apiUri, response)
+    getAuthenticationToken
+      .flatMap { tokenDetails =>
+        val apiUri = createApiUri(url, tokenDetails.apiUrl)
+        val request = basicRequest
+          .headers(
+            Map("Preservica-Access-Token" -> tokenDetails.token, "Content-Type" -> "application/json;charset=UTF-8")
+          )
+          .method(method, apiUri)
+          .readTimeout(Duration.Inf)
+          .response(asJson[R])
+        val requestWithBody: Request[Either[ResponseException[String], R]] =
+          requestBody.map(request.body(_)).getOrElse(request)
+        Async[F].blocking((apiUri, backend.send(requestWithBody)))
+      }
+      .flatMap { case (apiUri, response) =>
+        retrySend(method, apiUri, response)
+      }
   }
 
   private[client] def getAuthDetails(stage: Stage = Current): F[AuthDetails] =
-    memoizeF[F, AuthDetails](Some(duration)) {
-      Async[F]
-        .blocking {
-          val httpClient: SdkAsyncHttpClient = NettyNioAsyncHttpClient.builder().build()
-          val secretsManagerAsyncClient: SecretsManagerAsyncClient = SecretsManagerAsyncClient.builder
-            .region(Region.EU_WEST_2)
-            .credentialsProvider(DefaultCredentialsProvider.builder.build)
-            .endpointOverride(URI.create(secretsManagerEndpointUri))
-            .httpClient(httpClient)
-            .build()
-          DASecretsManagerClient[F](secretName, secretsManagerAsyncClient)
-        }
-        .flatMap { client =>
-          client.getSecretValue[AuthDetails](stage)
-        }
-    }
+    Async[F]
+      .blocking {
+        val httpClient: SdkAsyncHttpClient = NettyNioAsyncHttpClient.builder().build()
+        val secretsManagerAsyncClient: SecretsManagerAsyncClient = SecretsManagerAsyncClient.builder
+          .region(Region.EU_WEST_2)
+          .credentialsProvider(DefaultCredentialsProvider.builder.build)
+          .endpointOverride(URI.create(secretsManagerEndpointUri))
+          .httpClient(httpClient)
+          .build()
+        DASecretsManagerClient[F](secretName, secretsManagerAsyncClient)
+      }
+      .flatMap { client =>
+        client.getSecretValue[AuthDetails](stage)
+      }
 
   private[client] def generateToken(authDetails: AuthDetails): F[String] = {
     val request = basicRequest
       .body(Map("username" -> authDetails.userName, "password" -> authDetails.password))
-      .post(loginEndpointUri)
+      .post(loginEndpointUri(authDetails.apiUrl))
       .response(asJson[Token])
       .send(backend)
-    retrySend[Token, ResponseException[String]](Method.POST, loginEndpointUri, request).map(_.token)
+    retrySend[Token, ResponseException[String]](Method.POST, loginEndpointUri(authDetails.apiUrl), request).map(_.token)
   }
 
-  private[client] def getAuthenticationToken: F[String] =
-    memoizeF[F, String](Some(duration)) {
+  private[client] def getAuthenticationToken: F[TokenDetails] =
+    memoizeF[F, TokenDetails](Some(duration)) {
       for {
         authDetails <- getAuthDetails()
         token <- generateToken(authDetails)
-      } yield token
+      } yield TokenDetails(token, authDetails.apiUrl)
     }
 
   private[client] def getApiUrl: F[String] =
@@ -197,6 +200,8 @@ object Client {
   private[client] case class Token(token: String)
 
   private[client] case class AuthDetails(userName: String, password: String, apiUrl: String)
+
+  case class TokenDetails(token: String, apiUrl: String)
 
   /** Represents bitstream information from a content object
     *
@@ -228,8 +233,6 @@ object Client {
 
   /** Configuration for the clients
     *
-    * @param apiBaseUrl
-    *   The Preservica service url
     * @param secretName
     *   The name of the AWS secret storing the API username and password
     * @param backend
@@ -244,7 +247,6 @@ object Client {
     *   The type of the Stream for the client.
     */
   case class ClientConfig[F[_], S](
-      apiBaseUrl: String,
       secretName: String,
       backend: WebSocketStreamBackend[F, S],
       duration: FiniteDuration,

--- a/src/main/scala/uk/gov/nationalarchives/dp/client/Client.scala
+++ b/src/main/scala/uk/gov/nationalarchives/dp/client/Client.scala
@@ -189,9 +189,6 @@ private[client] class Client[F[_], S](clientConfig: ClientConfig[F, S])(using
         token <- generateToken(authDetails)
       } yield TokenDetails(token, authDetails.apiUrl)
     }
-
-  private[client] def getApiUrl: F[String] =
-    getAuthDetails().map(_.apiUrl)
 }
 
 /** Case classes common to several clients

--- a/src/main/scala/uk/gov/nationalarchives/dp/client/Client.scala
+++ b/src/main/scala/uk/gov/nationalarchives/dp/client/Client.scala
@@ -116,7 +116,7 @@ private[client] class Client[F[_], S](clientConfig: ClientConfig[F, S])(using
       url: String,
       method: Method,
       potentialRequestBody: Option[String] = None
-  ) = {
+  ) =
     getAuthenticationToken
       .flatMap { tokenDetails =>
         val apiUri = createApiUri(url, tokenDetails.apiUrl)
@@ -126,18 +126,16 @@ private[client] class Client[F[_], S](clientConfig: ClientConfig[F, S])(using
           .readTimeout(Duration.Inf)
           .response(asXml)
         val requestWithBody = potentialRequestBody.map(request.body(_)).getOrElse(request)
-        Async[F].blocking((apiUri, backend.send(requestWithBody)))
+        Async[F].blocking((apiUri, backend.send(requestWithBody))).flatMap { case (apiUri, response) =>
+          retrySend(method, apiUri, response)
+        }
       }
-      .flatMap { case (apiUri, response) =>
-        retrySend(method, apiUri, response)
-      }
-  }
 
   private[client] def sendJsonApiRequest[R: IsOption](
       url: String,
       method: Method,
       requestBody: Option[String] = None
-  )(using decoder: Decoder[R]): F[R] = {
+  )(using decoder: Decoder[R]): F[R] =
     getAuthenticationToken
       .flatMap { tokenDetails =>
         val apiUri = createApiUri(url, tokenDetails.apiUrl)
@@ -150,12 +148,10 @@ private[client] class Client[F[_], S](clientConfig: ClientConfig[F, S])(using
           .response(asJson[R])
         val requestWithBody: Request[Either[ResponseException[String], R]] =
           requestBody.map(request.body(_)).getOrElse(request)
-        Async[F].blocking((apiUri, backend.send(requestWithBody)))
+        Async[F].blocking((apiUri, backend.send(requestWithBody))).flatMap { case (apiUri, response) =>
+          retrySend(method, apiUri, response)
+        }
       }
-      .flatMap { case (apiUri, response) =>
-        retrySend(method, apiUri, response)
-      }
-  }
 
   private[client] def getAuthDetails(stage: Stage = Current): F[AuthDetails] =
     Async[F]

--- a/src/main/scala/uk/gov/nationalarchives/dp/client/ContentClient.scala
+++ b/src/main/scala/uk/gov/nationalarchives/dp/client/ContentClient.scala
@@ -7,7 +7,7 @@ import io.circe.syntax.*
 import sttp.client4.*
 import sttp.client4.circe.asJson
 import sttp.model.Uri
-import uk.gov.nationalarchives.dp.client.Client.ClientConfig
+import uk.gov.nationalarchives.dp.client.Client.{ClientConfig, TokenDetails}
 import uk.gov.nationalarchives.dp.client.ContentClient.SearchQuery
 import uk.gov.nationalarchives.dp.client.Entities.*
 
@@ -97,14 +97,14 @@ object ContentClient:
 
     private def search(
         start: Int,
-        token: String,
+        tokenDetails: TokenDetails,
         searchQuery: SearchQuery,
         ids: List[String]
     ): F[List[Entity]] =
       val max = 100
       basicRequest
-        .get(searchUri(start, max, searchQuery))
-        .headers(Map("Preservica-Access-Token" -> token))
+        .get(searchUri(tokenDetails.apiUrl, start, max, searchQuery))
+        .headers(Map("Preservica-Access-Token" -> tokenDetails.token))
         .response(asJson[SearchResponse])
         .send(backend)
         .flatMap(res => Async[F].fromEither(res.body))
@@ -112,10 +112,15 @@ object ContentClient:
           if searchResponse.value.objectIds.isEmpty then toEntities(ids)
           else
             Async[F]
-              .sleep(100.milliseconds) >> search(start + max, token, searchQuery, searchResponse.value.objectIds ++ ids)
+              .sleep(100.milliseconds) >> search(
+              start + max,
+              tokenDetails,
+              searchQuery,
+              searchResponse.value.objectIds ++ ids
+            )
         )
 
-    private def searchUri(start: Int, max: Int, searchQuery: SearchQuery): Uri =
+    private def searchUri(apiUrl: String, start: Int, max: Int, searchQuery: SearchQuery): Uri =
       val queryString = searchQuery.asJson.printWith(Printer.noSpaces)
       val queryParams = Map(
         "q" -> queryString,
@@ -123,7 +128,7 @@ object ContentClient:
         "max" -> max.toString,
         "metadata" -> searchQuery.fields.map(_.name).mkString(",")
       )
-      uri"$apiBaseUrl/api/content/search?$queryParams"
+      uri"$apiUrl/api/content/search?$queryParams"
 
     override def searchEntities(searchQuery: SearchQuery, max: Int = 100): F[List[Entity]] =
       for

--- a/src/main/scala/uk/gov/nationalarchives/dp/client/EntityClient.scala
+++ b/src/main/scala/uk/gov/nationalarchives/dp/client/EntityClient.scala
@@ -253,8 +253,7 @@ object EntityClient {
   def createEntityClient[F[_]: {Async, Parallel}, S](clientConfig: ClientConfig[F, S]): EntityClient[F, S] =
     new EntityClient[F, S] {
       val dateFormatter: DateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSSXXX")
-      private val apiBaseUrl: String = clientConfig.apiBaseUrl
-      private val apiUrl = s"$apiBaseUrl/api/entity/v$apiVersion"
+      private val apiUrl = s"api/entity/v$apiVersion"
       private val namespaceUrl = s"http://preservica.com/XIP/v$apiVersion"
 
       private val missingPathExceptionMessage: UUID => String = ref =>
@@ -518,8 +517,8 @@ object EntityClient {
           .response(asStream(stream)(streamFn))
 
         for {
-          token <- getAuthenticationToken
-          res <- backend.send(request(token))
+          tokenDetails <- getAuthenticationToken
+          res <- backend.send(request(tokenDetails.token))
           body <- Async[F].fromEither {
             res.body.left.map(err => PreservicaClientException(Method.GET, apiUri, res.code, err))
           }
@@ -546,7 +545,7 @@ object EntityClient {
 
       override def getPreservicaNamespaceVersion(endpoint: String): F[Float] = {
         for {
-          resXml <- sendXMLApiRequest(s"$apiBaseUrl/api/entity/$endpoint", Method.GET)
+          resXml <- sendXMLApiRequest(s"api/entity/$endpoint", Method.GET)
           version <- dataProcessor.getPreservicaNamespaceVersion(resXml)
         } yield version
       }

--- a/src/main/scala/uk/gov/nationalarchives/dp/client/ProcessMonitorClient.scala
+++ b/src/main/scala/uk/gov/nationalarchives/dp/client/ProcessMonitorClient.scala
@@ -48,7 +48,6 @@ object ProcessMonitorClient:
     */
   def createProcessMonitorClient[F[_]: Async](clientConfig: ClientConfig[F, ?]): ProcessMonitorClient[F] =
     new ProcessMonitorClient[F]:
-      private val apiBaseUrl: String = clientConfig.apiBaseUrl
       private val client: Client[F, ?] = Client(clientConfig)
 
       import client.*
@@ -156,7 +155,7 @@ object ProcessMonitorClient:
       override def getMonitors(getMonitorsRequest: GetMonitorsRequest): F[Seq[Monitors]] =
         val relevantQueryParamsAsString: Map[String, String] = getQueryParamsAsMap(getMonitorsRequest)
 
-        val getMonitorsUrl = uri"$apiBaseUrl/api/processmonitor/monitors?$relevantQueryParamsAsString"
+        val getMonitorsUrl = uri"api/processmonitor/monitors?$relevantQueryParamsAsString"
 
         for
           _ <-
@@ -176,7 +175,7 @@ object ProcessMonitorClient:
       ): F[Seq[Message]] =
         val relevantQueryParamsAsString: Map[String, String] = getQueryParamsAsMap(getMessagesRequest)
         val getMessagesUrl =
-          uri"$apiBaseUrl/api/processmonitor/messages?$relevantQueryParamsAsString&start=$start&max=$max"
+          uri"api/processmonitor/messages?$relevantQueryParamsAsString&start=$start&max=$max"
 
         monitorMessages(getMessagesUrl.toString, Nil)
 

--- a/src/main/scala/uk/gov/nationalarchives/dp/client/UserClient.scala
+++ b/src/main/scala/uk/gov/nationalarchives/dp/client/UserClient.scala
@@ -53,7 +53,7 @@ object UserClient:
       )
 
       _ <- client.sendJsonApiRequest[Option[String]](
-        s"${clientConfig.apiBaseUrl}/api/user/password",
+        s"api/user/password",
         Method.PUT,
         resetPasswordRequest.asJson.printWith(Printer.noSpaces).some
       )

--- a/src/main/scala/uk/gov/nationalarchives/dp/client/WorkflowClient.scala
+++ b/src/main/scala/uk/gov/nationalarchives/dp/client/WorkflowClient.scala
@@ -38,13 +38,12 @@ object WorkflowClient {
     */
   def createWorkflowClient[F[_]: Async, S](clientConfig: ClientConfig[F, S]): WorkflowClient[F] =
     new WorkflowClient[F] {
-      private val apiBaseUrl: String = clientConfig.apiBaseUrl
       private val client: Client[F, S] = Client(clientConfig)
 
       import client.*
 
       override def startWorkflow(startWorkflowRequest: StartWorkflowRequest): F[Int] = {
-        val startWorkflowUrl = uri"$apiBaseUrl/sdb/rest/workflow/instances"
+        val startWorkflowUrl = uri"sdb/rest/workflow/instances"
         val newLine = Some("\n  ")
 
         val workflowContextIdNode = startWorkflowRequest.workflowContextId


### PR DESCRIPTION
The Preservica API user being locked out on staging.

I have no specific proof of why this is but this is what I think is happening when we run a certain (not sure which one) lambda.

1. When the Preservica client is initialised, we get the secret from secrets manager and cache it.
2. Some other processes happen, probably a dynamo read.
3. While this is happening, the password is changed.
4. The lambda then tries to use the cached password which fails and locks out the account.

We’ve been seeing this on staging because TDR are load testing so there are many more lambda runs.

The fix is to stop the initial cache of the Preservica credentials and only cache the method which gets the secret and the token together. This will reduce the window for a race condition down to milliseconds so we should be ok.
