### PR TITLE
DR2-2666 Reduce retry count to 2

### DIFF
--- a/fs2/src/main/scala/uk/gov/nationalarchives/dp/client/fs2/Fs2Client.scala
+++ b/fs2/src/main/scala/uk/gov/nationalarchives/dp/client/fs2/Fs2Client.scala
@@ -43,7 +43,7 @@ object Fs2Client:
       duration: FiniteDuration = 15.minutes,
       ssmEndpointUri: String = defaultSecretsManagerEndpoint,
       potentialProxyUrl: Option[URI] = None,
-      retryCount: Int = 5
+      retryCount: Int = 2
   ): IO[EntityClient[IO, Fs2Streams[IO]]] =
     HttpClientFs2Backend.resource[IO](httpClientOptions(potentialProxyUrl)).use { backend =>
       val clientConfig = ClientConfig(secretName, backend, duration, ssmEndpointUri, retryCount)
@@ -66,7 +66,7 @@ object Fs2Client:
       duration: FiniteDuration = 15.minutes,
       ssmEndpointUri: String = defaultSecretsManagerEndpoint,
       potentialProxyUrl: Option[URI] = None,
-      retryCount: Int = 5
+      retryCount: Int = 2
   ): IO[ContentClient[IO]] =
     HttpClientFs2Backend.resource[IO](httpClientOptions(potentialProxyUrl)).use { backend =>
       val clientConfig = ClientConfig(secretName, backend, duration, ssmEndpointUri, retryCount)
@@ -88,7 +88,7 @@ object Fs2Client:
       duration: FiniteDuration = 15.minutes,
       ssmEndpointUri: String = defaultSecretsManagerEndpoint,
       potentialProxyUrl: Option[URI] = None,
-      retryCount: Int = 5
+      retryCount: Int = 2
   ): IO[WorkflowClient[IO]] =
     HttpClientFs2Backend.resource[IO](httpClientOptions(potentialProxyUrl)).use { backend =>
       val clientConfig = ClientConfig(secretName, backend, duration, ssmEndpointUri, retryCount)
@@ -112,7 +112,7 @@ object Fs2Client:
       duration: FiniteDuration = 15.minutes,
       ssmEndpointUri: String = defaultSecretsManagerEndpoint,
       potentialProxyUrl: Option[URI] = None,
-      retryCount: Int = 5
+      retryCount: Int = 2
   ): IO[ProcessMonitorClient[IO]] =
     HttpClientFs2Backend.resource[IO](httpClientOptions(potentialProxyUrl)).use { backend =>
       val clientConfig = ClientConfig(secretName, backend, duration, ssmEndpointUri, retryCount)
@@ -124,7 +124,7 @@ object Fs2Client:
       duration: FiniteDuration = 15.minutes,
       ssmEndpointUri: String = defaultSecretsManagerEndpoint,
       potentialProxyUrl: Option[URI] = None,
-      retryCount: Int = 5
+      retryCount: Int = 2
   ): IO[UserClient[IO]] =
     HttpClientFs2Backend.resource[IO](httpClientOptions(potentialProxyUrl)).use { backend =>
       val clientConfig = ClientConfig(secretName, backend, duration, ssmEndpointUri, retryCount)


### PR DESCRIPTION
We have a bug where if the client can't log into Preservice, usually through bad
credentials, the lambda times out because the retry count plus exponential backoff exceeds the lambda
timeout.

Rather than change each lambda individually, I'm going to change it in here.
There is a slight chance that something that didn't work after 2 times would have worked
after 5 but that's very unlikely and we have enough retry mechanisms in place that
it doesn't matter anyway.
